### PR TITLE
feat(phase2): tool registry with permission-tier filtering and confirm hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ ops-pilot/
 │   ├── fix_agent.py         ← LLM patch generation + PR via CI provider
 │   ├── notify_agent.py      ← Slack / webhook / console notification
 │   └── tools/
-│       └── triage_tools.py  ← GetFileTool, GetMoreLogTool, GetCommitDiffTool
+│       ├── triage_tools.py  ← GetFileTool, GetMoreLogTool, GetCommitDiffTool (READ_ONLY)
+│       └── fix_tools.py     ← GetRepoTreeTool, CreateBranchTool, UpdateFileTool, OpenDraftPRTool (WRITE)
 ├── providers/
 │   ├── base.py              ← CIProvider ABC (7 methods: get_failures, open_draft_pr, …)
 │   ├── github.py            ← GitHub Actions implementation
@@ -127,7 +128,8 @@ ops-pilot/
 │   └── factory.py           ← make_provider(pipeline, cfg) — wires config to provider
 ├── shared/
 │   ├── models.py            ← Pydantic models: Failure → Triage → Fix → Alert
-│   ├── agent_loop.py        ← Generic AgentLoop[T]: tool-use loop + Tool ABC + ToolContext
+│   ├── agent_loop.py        ← Generic AgentLoop[T]: tool-use loop + Tool ABC + ToolContext + confirm hook
+│   ├── tool_registry.py     ← ToolRegistry: permission-tier watermark (READ_ONLY ≤ WRITE ≤ DANGEROUS)
 │   ├── config.py            ← YAML config + env-var substitution + validation
 │   ├── llm_backend.py       ← LLMBackend Protocol + Anthropic / Bedrock / Vertex backends
 │   ├── task_queue.py        ← File-locked task queue (atomic rename, no broker needed)
@@ -227,6 +229,12 @@ The original TriageAgent sent one prompt and hoped the answer was in the last 50
 
 `AgentLoop` lets the model request exactly what it needs — `get_file`, `get_more_log`, `get_commit_diff` — and stop when it has enough signal. If it hits the turn limit before concluding, it escalates with partial findings rather than opening a PR based on a guess. A wrong fix is more expensive than a missed fix: it creates a PR engineers have to triage, and it erodes trust in the system.
 
+### Why a tool registry instead of passing tool lists directly?
+
+`TriageAgent` used to hardcode `[GetFileTool(), GetMoreLogTool(), GetCommitDiffTool()]`. That worked, but the safety guarantee ("triage never gets write tools") lived only in the developer's head.
+
+`ToolRegistry.get_tools(max_permission=READ_ONLY)` makes the blast-radius ceiling structural — TriageAgent declares its ceiling at construction time and the registry enforces it. Adding a new write tool to the catalog doesn't automatically make it available to triage; the agent has to explicitly raise its ceiling. `REQUIRES_CONFIRMATION` tools are excluded from all watermark queries and additionally gated at execution time by a `confirm` hook — no hook wired means the tool is always denied (fail-safe, not fail-open).
+
 ### Why draft PRs, not auto-merge?
 
 ops-pilot is a force multiplier, not a replacement for engineering judgment. It opens the PR, writes the description, and notifies the team. A human reviews the diff and merges. This keeps the system useful without making it dangerous.
@@ -242,7 +250,7 @@ Raw dicts break silently when a key is missing. Pydantic validates at constructi
 No local Python install required — runs inside Docker:
 
 ```bash
-docker compose run --rm test                  # 115 tests
+docker compose run --rm test                  # 155 tests
 docker compose run --rm test pytest -k triage # single agent
 docker compose run --rm test ruff check agents/ shared/
 ```

--- a/agents/tools/fix_tools.py
+++ b/agents/tools/fix_tools.py
@@ -1,0 +1,317 @@
+"""Fix tools — WRITE-tier tools for the ops-pilot tool registry.
+
+These tools wrap the write-side of the CIProvider interface. They are not
+currently used by FixAgent (which still orchestrates provider calls directly),
+but are registered in the tool catalog so future loop-driven fix agents and
+Phase 3 workers can discover and use them.
+
+Permission levels:
+  - GetRepoTreeTool : READ_ONLY  — safe listing, no side effects
+  - CreateBranchTool: WRITE      — creates a git branch
+  - UpdateFileTool  : WRITE      — commits a file change to a branch
+  - OpenDraftPRTool : WRITE      — opens a draft PR/MR
+
+All tools are stateless. Runtime dependencies arrive via ToolContext.
+"""
+
+from __future__ import annotations
+
+from shared.agent_loop import Permission, Tool, ToolContext, ToolResult
+
+
+class GetRepoTreeTool(Tool):
+    """List the file paths present in the repository at a given ref.
+
+    Use this when the triage output names an affected service but does not
+    specify which file to edit, or when get_file returns FileNotFoundError
+    and you need to discover the correct path. Returns a flat list of paths
+    filtered by the extensions you request.
+    """
+
+    @property
+    def name(self) -> str:
+        return "get_repo_tree"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List file paths in the repository at a given git ref. "
+            "Use this to discover which files exist when the triage analysis "
+            "references a service or module but not a specific file path. "
+            "Filter by extension to limit output to relevant file types. "
+            "Returns a sorted list of paths relative to the repo root."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "type": "string",
+                    "description": "Git ref (branch, tag, or commit SHA). Defaults to HEAD.",
+                },
+                "extensions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "File extensions to include, e.g. [\".py\", \".toml\"]. "
+                        "Omit to return all file types."
+                    ),
+                },
+            },
+            "required": [],
+        }
+
+    @property
+    def permission(self) -> Permission:
+        return Permission.READ_ONLY
+
+    async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
+        if ctx.provider is None:
+            return ToolResult("No provider available — cannot list repo tree.", is_error=True)
+
+        ref = input.get("ref", "HEAD")
+        raw_extensions = input.get("extensions")
+        extensions: tuple[str, ...] | None = None
+        if raw_extensions:
+            extensions = tuple(str(e) for e in raw_extensions)
+
+        repo = ctx.failure.pipeline.repo
+        try:
+            paths = ctx.provider.get_repo_tree(repo, ref=ref, extensions=extensions)
+            if not paths:
+                return ToolResult(
+                    f"No files found in {repo} at {ref}"
+                    + (f" with extensions {list(extensions)}" if extensions else "")
+                    + "."
+                )
+            listing = "\n".join(paths)
+            return ToolResult(
+                f"Repository tree: {repo} @ {ref} ({len(paths)} files)\n\n{listing}"
+            )
+        except Exception as exc:
+            return ToolResult(f"Failed to list repo tree: {exc}", is_error=True)
+
+
+class CreateBranchTool(Tool):
+    """Create a new git branch from an existing ref.
+
+    Use this as the first step before committing any fix — all file changes
+    must land on a dedicated ops-pilot branch, never directly on main.
+    The operation is idempotent: calling it when the branch already exists
+    is safe and returns a success result.
+    """
+
+    @property
+    def name(self) -> str:
+        return "create_branch"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Create a new git branch from an existing branch or commit SHA. "
+            "Always call this before update_file — never commit directly to main. "
+            "Use the naming convention 'ops-pilot/fix-<short-sha>' for the branch "
+            "name so fix PRs are easy to identify and filter. "
+            "Idempotent: safe to call if the branch already exists."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string",
+                    "description": (
+                        "New branch name. Convention: 'ops-pilot/fix-<7-char-sha>', "
+                        "e.g. 'ops-pilot/fix-abc1234'."
+                    ),
+                },
+                "from_ref": {
+                    "type": "string",
+                    "description": "Branch name or commit SHA to branch from (typically 'main').",
+                },
+            },
+            "required": ["branch", "from_ref"],
+        }
+
+    @property
+    def permission(self) -> Permission:
+        return Permission.WRITE
+
+    async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
+        if ctx.provider is None:
+            return ToolResult("No provider available — cannot create branch.", is_error=True)
+
+        repo = ctx.failure.pipeline.repo
+        branch = input["branch"]
+        from_ref = input["from_ref"]
+        try:
+            ctx.provider.create_branch(repo, branch, from_ref=from_ref)
+            return ToolResult(f"Branch '{branch}' created from '{from_ref}' in {repo}.")
+        except Exception as exc:
+            return ToolResult(f"Failed to create branch '{branch}': {exc}", is_error=True)
+
+
+class UpdateFileTool(Tool):
+    """Commit updated file content to an existing branch.
+
+    Writes the complete new file content to the specified path on the branch.
+    You must have the blob_id from a prior get_file call — it is the conflict
+    guard that prevents overwriting concurrent changes. For GitLab, pass an
+    empty string for blob_id.
+    """
+
+    @property
+    def name(self) -> str:
+        return "update_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Commit a new version of a file to an existing branch. "
+            "You must call get_file first to obtain the blob_id (the conflict guard). "
+            "Provide the complete new file content — not a diff. Make the minimal "
+            "change that fixes the bug; do not reformat unrelated code. "
+            "For GitLab providers, blob_id can be an empty string."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path relative to the repo root.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Complete new file content (not a diff).",
+                },
+                "blob_id": {
+                    "type": "string",
+                    "description": (
+                        "Blob identifier from a prior get_file call. "
+                        "Required for GitHub to prevent conflicts. "
+                        "Pass empty string for GitLab."
+                    ),
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Target branch to commit to (must already exist).",
+                },
+                "commit_message": {
+                    "type": "string",
+                    "description": "Commit message. Use imperative mood, e.g. 'fix: restore null guard'.",
+                },
+            },
+            "required": ["path", "content", "branch", "commit_message"],
+        }
+
+    @property
+    def permission(self) -> Permission:
+        return Permission.WRITE
+
+    async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
+        if ctx.provider is None:
+            return ToolResult("No provider available — cannot update file.", is_error=True)
+
+        repo = ctx.failure.pipeline.repo
+        path = input["path"]
+        content = input["content"]
+        blob_id = input.get("blob_id", "")
+        branch = input["branch"]
+        commit_message = input["commit_message"]
+        try:
+            ctx.provider.update_file(
+                repo=repo,
+                path=path,
+                content=content,
+                blob_id=blob_id,
+                branch=branch,
+                commit_message=commit_message,
+            )
+            return ToolResult(
+                f"Committed '{path}' to branch '{branch}' in {repo}.\n"
+                f"Message: {commit_message}"
+            )
+        except Exception as exc:
+            return ToolResult(f"Failed to update '{path}': {exc}", is_error=True)
+
+
+class OpenDraftPRTool(Tool):
+    """Open a draft PR or MR targeting the base branch.
+
+    Call this after all file changes have been committed to the fix branch.
+    The operation is idempotent: if a PR for the same head branch already
+    exists, the existing PR URL and number are returned instead of creating
+    a duplicate.
+    """
+
+    @property
+    def name(self) -> str:
+        return "open_draft_pr"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Open a draft pull request (GitHub) or merge request (GitLab) "
+            "targeting the base branch. Call this after all file changes are "
+            "committed to the fix branch. "
+            "The PR title should be under 72 characters in imperative mood. "
+            "The PR body should use sections: ## Problem / ## Root cause / ## Fix / ## Tests. "
+            "Idempotent: returns the existing PR if one already exists for the head branch."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "PR title, imperative mood, under 72 characters.",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Full markdown PR body.",
+                },
+                "head": {
+                    "type": "string",
+                    "description": "Source branch (the ops-pilot fix branch).",
+                },
+                "base": {
+                    "type": "string",
+                    "description": "Target branch, typically 'main'.",
+                },
+            },
+            "required": ["title", "body", "head", "base"],
+        }
+
+    @property
+    def permission(self) -> Permission:
+        return Permission.WRITE
+
+    async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
+        if ctx.provider is None:
+            return ToolResult("No provider available — cannot open PR.", is_error=True)
+
+        repo = ctx.failure.pipeline.repo
+        title = input["title"]
+        body = input["body"]
+        head = input["head"]
+        base = input["base"]
+        try:
+            url, number = ctx.provider.open_draft_pr(
+                repo=repo,
+                title=title,
+                body=body,
+                head=head,
+                base=base,
+            )
+            return ToolResult(f"Draft PR #{number} opened: {url}")
+        except Exception as exc:
+            return ToolResult(f"Failed to open draft PR: {exc}", is_error=True)

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -29,8 +29,9 @@ from typing import TYPE_CHECKING
 
 from agents.base_agent import BaseAgent
 from agents.tools.triage_tools import GetCommitDiffTool, GetFileTool, GetMoreLogTool
-from shared.agent_loop import AgentLoop, LoopOutcome, LoopResult, ToolContext
+from shared.agent_loop import AgentLoop, LoopOutcome, LoopResult, Permission, ToolContext
 from shared.models import AgentStatus, Failure, Severity, Triage
+from shared.tool_registry import ToolRegistry
 
 if TYPE_CHECKING:
     from providers.base import CIProvider
@@ -87,10 +88,17 @@ class TriageAgent(BaseAgent[Triage]):
         model: str | None = None,
         provider: CIProvider | None = None,
         max_turns: int = 10,
+        registry: ToolRegistry | None = None,
     ) -> None:
         super().__init__(backend=backend, model=model)
         self._provider = provider
         self._max_turns = max_turns
+        if registry is None:
+            registry = ToolRegistry()
+            registry.register(GetFileTool())
+            registry.register(GetMoreLogTool())
+            registry.register(GetCommitDiffTool())
+        self._registry = registry
 
     def describe(self) -> str:
         return "Analyses CI logs and diffs to identify root causes via agentic tool use"
@@ -137,7 +145,7 @@ class TriageAgent(BaseAgent[Triage]):
     async def _run_loop(self, failure: Failure) -> LoopResult[Triage]:
         """Build and run the AgentLoop for one failure."""
         loop: AgentLoop[Triage] = AgentLoop(
-            tools=[GetFileTool(), GetMoreLogTool(), GetCommitDiffTool()],
+            tools=self._registry.get_tools(max_permission=Permission.READ_ONLY),
             backend=self.backend,
             domain_system_prompt=SYSTEM_PROMPT,
             response_model=Triage,

--- a/shared/agent_loop.py
+++ b/shared/agent_loop.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
@@ -262,8 +263,10 @@ class AgentLoop(Generic[T]):
         max_turns: int = 10,
         tool_timeout: float = 30.0,
         max_tokens: int = 4096,
+        confirm: Callable[[Tool, dict], Awaitable[bool]] | None = None,
     ) -> None:
         self._tools: dict[str, Tool] = {t.name: t for t in tools}
+        self._confirm = confirm
         self._backend = backend
         self._response_model = response_model
         self._model = model
@@ -419,6 +422,32 @@ class AgentLoop(Generic[T]):
                     ),
                     "is_error": True,
                 }
+
+            # ── Confirmation gate ────────────────────────────────────────────
+            # REQUIRES_CONFIRMATION tools are blocked unless a confirm hook is
+            # wired and approves. Fail-safe: no hook → denied. The model receives
+            # a clear error message and can adapt (explain what it would do, ask
+            # for escalation, etc.). Never silently skip the tool_result — the
+            # API requires every tool_use to have a paired result.
+            if tool.permission == Permission.REQUIRES_CONFIRMATION:
+                approved = (
+                    self._confirm is not None
+                    and await self._confirm(tool, block.input)
+                )
+                if not approved:
+                    failed_tools.append(block.name)
+                    return {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": (
+                            f"Tool '{block.name}' requires explicit confirmation "
+                            "before execution. No confirmation hook is configured "
+                            "— action blocked. Summarise what you intended to do "
+                            "and why, so a human can review and approve."
+                        ),
+                        "is_error": True,
+                    }
+
             try:
                 result = await asyncio.wait_for(
                     tool.execute(block.input, ctx),

--- a/shared/tool_registry.py
+++ b/shared/tool_registry.py
@@ -1,0 +1,116 @@
+"""Tool registry for ops-pilot agent loops.
+
+Central catalog of all available tools with permission-tier filtering.
+Agents query the registry at construction time to get a tool list scoped to
+their blast-radius ceiling — TriageAgent asks for READ_ONLY, FixAgent for WRITE.
+
+The registry answers one question: given a permission ceiling, which tools
+are appropriate for this agent? It does not own execution or confirmation logic.
+Those responsibilities stay in AgentLoop.
+
+Permission model:
+  - READ_ONLY and WRITE form a linear watermark tier (READ_ONLY ≤ WRITE).
+  - DANGEROUS and REQUIRES_CONFIRMATION are outside the linear tier. They are
+    excluded by default and require explicit opt-in via include_dangerous=True.
+    Even when included, REQUIRES_CONFIRMATION tools are still blocked at
+    execution time unless AgentLoop is constructed with a confirmation hook.
+"""
+
+from __future__ import annotations
+
+from shared.agent_loop import Permission, Tool
+
+# Linear tier ordering for the watermark filter.
+# Only READ_ONLY and WRITE participate — DANGEROUS and REQUIRES_CONFIRMATION
+# are outside this ordering and handled separately.
+_TIER_ORDER: dict[Permission, int] = {
+    Permission.READ_ONLY: 0,
+    Permission.WRITE: 1,
+}
+
+
+class ToolRegistry:
+    """Central catalog of available tools, queryable by permission tier.
+
+    Tools are registered at startup and retrieved by agents at construction
+    time. The registry does not mutate after population.
+
+    Example usage::
+
+        registry = ToolRegistry()
+        registry.register(GetFileTool())
+        registry.register(UpdateFileTool())
+
+        # Triage agent — read only
+        triage_tools = registry.get_tools(max_permission=Permission.READ_ONLY)
+
+        # Fix agent — can also write
+        fix_tools = registry.get_tools(max_permission=Permission.WRITE)
+    """
+
+    def __init__(self) -> None:
+        # Ordered dict preserves registration order, which becomes tool list
+        # order. Consistent ordering helps with deterministic test assertions.
+        self._tools: dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        """Add a tool to the registry.
+
+        Args:
+            tool: Tool instance to register.
+
+        Raises:
+            ValueError: If a tool with the same name is already registered.
+                        Duplicate names would silently shadow tools otherwise.
+        """
+        if tool.name in self._tools:
+            raise ValueError(
+                f"Tool '{tool.name}' is already registered. "
+                "Use a distinct name or deregister the existing tool first."
+            )
+        self._tools[tool.name] = tool
+
+    def get_tools(
+        self,
+        max_permission: Permission = Permission.READ_ONLY,
+        include_dangerous: bool = False,
+    ) -> list[Tool]:
+        """Return tools that fit within the given permission ceiling.
+
+        The watermark applies only to the READ_ONLY / WRITE tier. DANGEROUS and
+        REQUIRES_CONFIRMATION tools are orthogonally gated by include_dangerous.
+
+        Args:
+            max_permission:   Highest tier to include. READ_ONLY → read tools
+                              only. WRITE → read + write tools.
+            include_dangerous: If True, also include DANGEROUS and
+                               REQUIRES_CONFIRMATION tools. These are excluded
+                               by default. Note that REQUIRES_CONFIRMATION tools
+                               will still be blocked at execution time if
+                               AgentLoop has no confirmation hook wired.
+
+        Returns:
+            List of matching tools in registration order.
+        """
+        max_tier = _TIER_ORDER.get(max_permission, 0)
+        result: list[Tool] = []
+        for tool in self._tools.values():
+            tier = _TIER_ORDER.get(tool.permission)
+            if tier is not None:
+                # Tiered tool: include only if within the watermark ceiling
+                if tier <= max_tier:
+                    result.append(tool)
+            elif include_dangerous:
+                # Non-tiered (DANGEROUS / REQUIRES_CONFIRMATION): opt-in only
+                result.append(tool)
+        return result
+
+    def all_tool_names(self) -> list[str]:
+        """Return all registered tool names regardless of permission tier.
+
+        Useful for logging and diagnostics.
+        """
+        return list(self._tools.keys())
+
+    def __len__(self) -> int:
+        return len(self._tools)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel
 from shared.agent_loop import (
     AgentLoop,
     LoopOutcome,
+    Permission,
     Tool,
     ToolContext,
     ToolResult,
@@ -629,3 +630,138 @@ class TestToolExecution:
         second_call_messages = backend.complete_with_tools.call_args_list[1][1]["messages"]
         tool_result = second_call_messages[2]["content"][0]
         assert tool_result.get("is_error") is True
+
+
+# ── Tests: confirmation hook ───────────────────────────────────────────────────
+
+class ConfirmationTool(Tool):
+    """A tool that requires confirmation before it executes."""
+
+    def __init__(self) -> None:
+        self.executed = False
+
+    @property
+    def name(self) -> str:
+        return "confirm_action"
+
+    @property
+    def description(self) -> str:
+        return "A tool that requires confirmation"
+
+    @property
+    def input_schema(self) -> dict:
+        return {"type": "object", "properties": {}}
+
+    @property
+    def permission(self) -> Permission:
+        return Permission.REQUIRES_CONFIRMATION
+
+    async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
+        self.executed = True
+        return ToolResult("action executed")
+
+
+class TestConfirmHook:
+    async def test_requires_confirmation_blocked_when_no_hook(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """REQUIRES_CONFIRMATION tool is blocked by default (confirm=None → deny)."""
+        tool = ConfirmationTool()
+        backend = _make_backend([
+            _response(_tool_block("confirm_action", {}, "t1")),
+            _end_turn(),
+        ])
+        # No confirm hook — fail-safe
+        loop = _make_loop(tools=[tool], backend=backend)
+        result = await loop.run(
+            messages=[{"role": "user", "content": "go"}],
+            ctx=tool_ctx,
+        )
+
+        # Tool must NOT have executed
+        assert not tool.executed
+        # Must still produce an error tool_result (never skip the pair)
+        assert "confirm_action" in result.failed_tools
+        second_call_messages = backend.complete_with_tools.call_args_list[1][1]["messages"]
+        tool_result = second_call_messages[2]["content"][0]
+        assert tool_result.get("is_error") is True
+        assert "confirmation" in tool_result["content"].lower()
+
+    async def test_requires_confirmation_executes_when_hook_approves(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """REQUIRES_CONFIRMATION tool runs when confirm hook returns True."""
+        tool = ConfirmationTool()
+        backend = _make_backend([
+            _response(_tool_block("confirm_action", {}, "t1")),
+            _end_turn(),
+        ])
+
+        async def auto_approve(t: Tool, inp: dict) -> bool:
+            return True
+
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            max_turns=5,
+            confirm=auto_approve,
+        )
+        result = await loop.run(
+            messages=[{"role": "user", "content": "go"}],
+            ctx=tool_ctx,
+        )
+
+        assert tool.executed
+        assert "confirm_action" not in result.failed_tools
+
+    async def test_requires_confirmation_blocked_when_hook_denies(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """REQUIRES_CONFIRMATION tool is blocked when confirm hook returns False."""
+        tool = ConfirmationTool()
+        backend = _make_backend([
+            _response(_tool_block("confirm_action", {}, "t1")),
+            _end_turn(),
+        ])
+
+        async def auto_deny(t: Tool, inp: dict) -> bool:
+            return False
+
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            max_turns=5,
+            confirm=auto_deny,
+        )
+        result = await loop.run(
+            messages=[{"role": "user", "content": "go"}],
+            ctx=tool_ctx,
+        )
+
+        assert not tool.executed
+        assert "confirm_action" in result.failed_tools
+
+    async def test_read_only_tool_not_gated_by_confirm(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """READ_ONLY tools execute without needing a confirm hook."""
+        tool = RecordingTool("safe_tool")
+        backend = _make_backend([
+            _response(_tool_block("safe_tool", {}, "t1")),
+            _end_turn(),
+        ])
+        # No confirm hook — should not affect read-only tools
+        loop = _make_loop(tools=[tool], backend=backend)
+        result = await loop.run(
+            messages=[{"role": "user", "content": "go"}],
+            ctx=tool_ctx,
+        )
+
+        assert len(tool.calls) == 1
+        assert "safe_tool" not in result.failed_tools

--- a/tests/test_fix_tools.py
+++ b/tests/test_fix_tools.py
@@ -8,7 +8,6 @@ stateless, so each test constructs a fresh instance.
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -20,9 +19,8 @@ from agents.tools.fix_tools import (
     OpenDraftPRTool,
     UpdateFileTool,
 )
-from shared.agent_loop import Permission, ToolContext, ToolResult
+from shared.agent_loop import Permission, ToolContext
 from shared.models import DiffSummary, Failure, FailureDetail, PipelineInfo
-
 
 # ── Fixtures ───────────────────────────────────────────────────────────────────
 

--- a/tests/test_fix_tools.py
+++ b/tests/test_fix_tools.py
@@ -1,0 +1,316 @@
+"""Tests for fix tools — the WRITE-tier tools in the tool registry.
+
+Testing strategy: each test provides a mock CIProvider via ToolContext.
+We assert on ToolResult.content and ToolResult.is_error, and verify the
+correct provider method was called with the correct arguments. Tools are
+stateless, so each test constructs a fresh instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agents.tools.fix_tools import (
+    CreateBranchTool,
+    GetRepoTreeTool,
+    OpenDraftPRTool,
+    UpdateFileTool,
+)
+from shared.agent_loop import Permission, ToolContext, ToolResult
+from shared.models import DiffSummary, Failure, FailureDetail, PipelineInfo
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def failure() -> Failure:
+    return Failure(
+        id="fix_test_001",
+        pipeline=PipelineInfo(
+            provider="github_actions",
+            repo="acme/backend",
+            workflow="ci.yml",
+            run_id="99001",
+            branch="main",
+            commit="def5678",
+            commit_message="chore: bump deps",
+            author="dev@acme.com",
+            triggered_at=datetime(2026, 1, 1),
+            failed_at=datetime(2026, 1, 1),
+            duration_seconds=30,
+        ),
+        failure=FailureDetail(
+            job="test-job",
+            step="pytest",
+            exit_code=1,
+            log_tail=["FAILED test_auth.py::test_login"],
+        ),
+        diff_summary=DiffSummary(
+            files_changed=["auth.py"],
+            lines_added=1,
+            lines_removed=1,
+            key_change="removed null guard",
+        ),
+    )
+
+
+@pytest.fixture
+def mock_provider() -> MagicMock:
+    """Mock CIProvider with stubs for all methods used by fix tools."""
+    p = MagicMock()
+    p.get_repo_tree.return_value = ["auth.py", "models.py", "tests/test_auth.py"]
+    p.create_branch.return_value = None
+    p.update_file.return_value = None
+    p.open_draft_pr.return_value = ("https://github.com/acme/backend/pull/42", 42)
+    return p
+
+
+@pytest.fixture
+def ctx(failure: Failure, mock_provider: MagicMock) -> ToolContext:
+    return ToolContext(provider=mock_provider, failure=failure)
+
+
+@pytest.fixture
+def ctx_no_provider(failure: Failure) -> ToolContext:
+    return ToolContext(provider=None, failure=failure)
+
+
+# ── GetRepoTreeTool ────────────────────────────────────────────────────────────
+
+class TestGetRepoTreeTool:
+    def test_permission_is_read_only(self) -> None:
+        assert GetRepoTreeTool().permission == Permission.READ_ONLY
+
+    async def test_returns_file_listing(self, ctx: ToolContext) -> None:
+        result = await GetRepoTreeTool().execute({}, ctx)
+        assert not result.is_error
+        assert "auth.py" in result.content
+        assert "models.py" in result.content
+
+    async def test_passes_ref_to_provider(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        await GetRepoTreeTool().execute({"ref": "abc1234"}, ctx)
+        mock_provider.get_repo_tree.assert_called_once_with(
+            "acme/backend", ref="abc1234", extensions=None
+        )
+
+    async def test_passes_extensions_to_provider(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        await GetRepoTreeTool().execute({"extensions": [".py", ".toml"]}, ctx)
+        _, kwargs = mock_provider.get_repo_tree.call_args
+        assert kwargs["extensions"] == (".py", ".toml")
+
+    async def test_default_ref_is_head(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        await GetRepoTreeTool().execute({}, ctx)
+        _, kwargs = mock_provider.get_repo_tree.call_args
+        assert kwargs["ref"] == "HEAD"
+
+    async def test_empty_tree_returns_success_message(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        mock_provider.get_repo_tree.return_value = []
+        result = await GetRepoTreeTool().execute({}, ctx)
+        assert not result.is_error
+        assert "No files found" in result.content
+
+    async def test_no_provider_returns_error(self, ctx_no_provider: ToolContext) -> None:
+        result = await GetRepoTreeTool().execute({}, ctx_no_provider)
+        assert result.is_error
+
+    async def test_provider_exception_returns_error(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        mock_provider.get_repo_tree.side_effect = RuntimeError("API down")
+        result = await GetRepoTreeTool().execute({}, ctx)
+        assert result.is_error
+        assert "API down" in result.content
+
+
+# ── CreateBranchTool ──────────────────────────────────────────────────────────
+
+class TestCreateBranchTool:
+    def test_permission_is_write(self) -> None:
+        assert CreateBranchTool().permission == Permission.WRITE
+
+    async def test_creates_branch_via_provider(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        result = await CreateBranchTool().execute(
+            {"branch": "ops-pilot/fix-def5678", "from_ref": "main"}, ctx
+        )
+        assert not result.is_error
+        mock_provider.create_branch.assert_called_once_with(
+            "acme/backend", "ops-pilot/fix-def5678", from_ref="main"
+        )
+
+    async def test_success_message_contains_branch_name(
+        self, ctx: ToolContext
+    ) -> None:
+        result = await CreateBranchTool().execute(
+            {"branch": "ops-pilot/fix-def5678", "from_ref": "main"}, ctx
+        )
+        assert "ops-pilot/fix-def5678" in result.content
+
+    async def test_no_provider_returns_error(self, ctx_no_provider: ToolContext) -> None:
+        result = await CreateBranchTool().execute(
+            {"branch": "ops-pilot/fix-def5678", "from_ref": "main"}, ctx_no_provider
+        )
+        assert result.is_error
+
+    async def test_provider_exception_returns_error(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        mock_provider.create_branch.side_effect = RuntimeError("permission denied")
+        result = await CreateBranchTool().execute(
+            {"branch": "ops-pilot/fix-def5678", "from_ref": "main"}, ctx
+        )
+        assert result.is_error
+        assert "permission denied" in result.content
+
+
+# ── UpdateFileTool ─────────────────────────────────────────────────────────────
+
+class TestUpdateFileTool:
+    def test_permission_is_write(self) -> None:
+        assert UpdateFileTool().permission == Permission.WRITE
+
+    async def test_commits_file_via_provider(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        result = await UpdateFileTool().execute(
+            {
+                "path": "auth.py",
+                "content": "def login(): return True",
+                "blob_id": "abc123blob",
+                "branch": "ops-pilot/fix-def5678",
+                "commit_message": "fix: restore null guard",
+            },
+            ctx,
+        )
+        assert not result.is_error
+        mock_provider.update_file.assert_called_once_with(
+            repo="acme/backend",
+            path="auth.py",
+            content="def login(): return True",
+            blob_id="abc123blob",
+            branch="ops-pilot/fix-def5678",
+            commit_message="fix: restore null guard",
+        )
+
+    async def test_blob_id_defaults_to_empty_string(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        """blob_id is optional — GitLab providers accept empty string."""
+        await UpdateFileTool().execute(
+            {
+                "path": "auth.py",
+                "content": "fixed content",
+                "branch": "ops-pilot/fix-def5678",
+                "commit_message": "fix: test",
+            },
+            ctx,
+        )
+        _, kwargs = mock_provider.update_file.call_args
+        assert kwargs["blob_id"] == ""
+
+    async def test_success_message_contains_path_and_branch(
+        self, ctx: ToolContext
+    ) -> None:
+        result = await UpdateFileTool().execute(
+            {
+                "path": "auth.py",
+                "content": "x",
+                "branch": "ops-pilot/fix-def5678",
+                "commit_message": "fix: test",
+            },
+            ctx,
+        )
+        assert "auth.py" in result.content
+        assert "ops-pilot/fix-def5678" in result.content
+
+    async def test_no_provider_returns_error(self, ctx_no_provider: ToolContext) -> None:
+        result = await UpdateFileTool().execute(
+            {"path": "auth.py", "content": "x", "branch": "b", "commit_message": "m"},
+            ctx_no_provider,
+        )
+        assert result.is_error
+
+    async def test_provider_exception_returns_error(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        mock_provider.update_file.side_effect = RuntimeError("conflict")
+        result = await UpdateFileTool().execute(
+            {"path": "auth.py", "content": "x", "branch": "b", "commit_message": "m"},
+            ctx,
+        )
+        assert result.is_error
+        assert "conflict" in result.content
+
+
+# ── OpenDraftPRTool ────────────────────────────────────────────────────────────
+
+class TestOpenDraftPRTool:
+    def test_permission_is_write(self) -> None:
+        assert OpenDraftPRTool().permission == Permission.WRITE
+
+    async def test_opens_pr_via_provider(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        result = await OpenDraftPRTool().execute(
+            {
+                "title": "fix(auth): restore null guard",
+                "body": "## Problem\nNull guard removed.\n",
+                "head": "ops-pilot/fix-def5678",
+                "base": "main",
+            },
+            ctx,
+        )
+        assert not result.is_error
+        mock_provider.open_draft_pr.assert_called_once_with(
+            repo="acme/backend",
+            title="fix(auth): restore null guard",
+            body="## Problem\nNull guard removed.\n",
+            head="ops-pilot/fix-def5678",
+            base="main",
+        )
+
+    async def test_result_contains_pr_url_and_number(
+        self, ctx: ToolContext
+    ) -> None:
+        result = await OpenDraftPRTool().execute(
+            {
+                "title": "fix: test",
+                "body": "body",
+                "head": "ops-pilot/fix-def5678",
+                "base": "main",
+            },
+            ctx,
+        )
+        assert "42" in result.content
+        assert "https://github.com/acme/backend/pull/42" in result.content
+
+    async def test_no_provider_returns_error(self, ctx_no_provider: ToolContext) -> None:
+        result = await OpenDraftPRTool().execute(
+            {"title": "t", "body": "b", "head": "h", "base": "main"},
+            ctx_no_provider,
+        )
+        assert result.is_error
+
+    async def test_provider_exception_returns_error(
+        self, ctx: ToolContext, mock_provider: MagicMock
+    ) -> None:
+        mock_provider.open_draft_pr.side_effect = RuntimeError("rate limited")
+        result = await OpenDraftPRTool().execute(
+            {"title": "t", "body": "b", "head": "h", "base": "main"},
+            ctx,
+        )
+        assert result.is_error
+        assert "rate limited" in result.content

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 
 import pytest
 
-from shared.agent_loop import Permission, Tool, ToolContext, ToolResult
+from shared.agent_loop import Permission, Tool, ToolContext, ToolResult  # noqa: F401
 from shared.tool_registry import ToolRegistry
-
 
 # ── Minimal test tools at each permission tier ────────────────────────────────
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,163 @@
+"""Tests for ToolRegistry — permission-tier filtering and registration.
+
+Testing strategy: use lightweight in-process Tool subclasses rather than the
+real tools. This keeps tests fast and isolated from provider concerns. We test
+the registry in isolation; tests for how agents use the registry live in the
+agent test files.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.agent_loop import Permission, Tool, ToolContext, ToolResult
+from shared.tool_registry import ToolRegistry
+
+
+# ── Minimal test tools at each permission tier ────────────────────────────────
+
+def _make_tool(name: str, perm: Permission) -> Tool:
+    """Factory: returns a minimal Tool instance at the given permission tier."""
+
+    class _T(Tool):
+        @property
+        def name(self) -> str:
+            return name
+
+        @property
+        def description(self) -> str:
+            return f"Test tool {name}"
+
+        @property
+        def input_schema(self) -> dict:
+            return {"type": "object", "properties": {}}
+
+        @property
+        def permission(self) -> Permission:
+            return perm
+
+        async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
+            return ToolResult(f"{name} executed")
+
+    return _T()
+
+
+@pytest.fixture
+def populated_registry() -> ToolRegistry:
+    """Registry with one tool at every permission tier."""
+    reg = ToolRegistry()
+    reg.register(_make_tool("read_tool", Permission.READ_ONLY))
+    reg.register(_make_tool("write_tool", Permission.WRITE))
+    reg.register(_make_tool("dangerous_tool", Permission.DANGEROUS))
+    reg.register(_make_tool("confirm_tool", Permission.REQUIRES_CONFIRMATION))
+    return reg
+
+
+# ── Registration ──────────────────────────────────────────────────────────────
+
+class TestRegistration:
+    def test_register_adds_tool(self) -> None:
+        reg = ToolRegistry()
+        reg.register(_make_tool("my_tool", Permission.READ_ONLY))
+        assert "my_tool" in reg.all_tool_names()
+
+    def test_duplicate_name_raises(self) -> None:
+        reg = ToolRegistry()
+        reg.register(_make_tool("dup", Permission.READ_ONLY))
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register(_make_tool("dup", Permission.WRITE))
+
+    def test_len_reflects_registrations(self) -> None:
+        reg = ToolRegistry()
+        assert len(reg) == 0
+        reg.register(_make_tool("a", Permission.READ_ONLY))
+        reg.register(_make_tool("b", Permission.WRITE))
+        assert len(reg) == 2
+
+    def test_registration_order_preserved(self) -> None:
+        reg = ToolRegistry()
+        names = ["first", "second", "third"]
+        for n in names:
+            reg.register(_make_tool(n, Permission.READ_ONLY))
+        result_names = [t.name for t in reg.get_tools(max_permission=Permission.READ_ONLY)]
+        assert result_names == names
+
+
+# ── Watermark filtering ───────────────────────────────────────────────────────
+
+class TestWatermarkFiltering:
+    def test_read_only_watermark_returns_only_read_tools(
+        self, populated_registry: ToolRegistry
+    ) -> None:
+        tools = populated_registry.get_tools(max_permission=Permission.READ_ONLY)
+        names = {t.name for t in tools}
+        assert names == {"read_tool"}
+
+    def test_write_watermark_returns_read_and_write_tools(
+        self, populated_registry: ToolRegistry
+    ) -> None:
+        tools = populated_registry.get_tools(max_permission=Permission.WRITE)
+        names = {t.name for t in tools}
+        assert names == {"read_tool", "write_tool"}
+
+    def test_dangerous_and_confirm_excluded_by_default(
+        self, populated_registry: ToolRegistry
+    ) -> None:
+        """DANGEROUS and REQUIRES_CONFIRMATION never appear in watermark queries."""
+        for max_perm in (Permission.READ_ONLY, Permission.WRITE):
+            tools = populated_registry.get_tools(max_permission=max_perm)
+            names = {t.name for t in tools}
+            assert "dangerous_tool" not in names
+            assert "confirm_tool" not in names
+
+    def test_include_dangerous_adds_non_tiered_tools(
+        self, populated_registry: ToolRegistry
+    ) -> None:
+        tools = populated_registry.get_tools(
+            max_permission=Permission.READ_ONLY,
+            include_dangerous=True,
+        )
+        names = {t.name for t in tools}
+        assert "dangerous_tool" in names
+        assert "confirm_tool" in names
+        # Watermark still applies to tiered tools
+        assert "write_tool" not in names
+
+    def test_include_dangerous_with_write_watermark(
+        self, populated_registry: ToolRegistry
+    ) -> None:
+        tools = populated_registry.get_tools(
+            max_permission=Permission.WRITE,
+            include_dangerous=True,
+        )
+        names = {t.name for t in tools}
+        assert names == {"read_tool", "write_tool", "dangerous_tool", "confirm_tool"}
+
+    def test_empty_registry_returns_empty_list(self) -> None:
+        reg = ToolRegistry()
+        assert reg.get_tools(max_permission=Permission.WRITE) == []
+
+    def test_returns_list_not_dict(self, populated_registry: ToolRegistry) -> None:
+        result = populated_registry.get_tools()
+        assert isinstance(result, list)
+
+    def test_default_max_permission_is_read_only(
+        self, populated_registry: ToolRegistry
+    ) -> None:
+        """Calling get_tools() with no args defaults to READ_ONLY watermark."""
+        default_result = populated_registry.get_tools()
+        explicit_result = populated_registry.get_tools(max_permission=Permission.READ_ONLY)
+        assert {t.name for t in default_result} == {t.name for t in explicit_result}
+
+
+# ── all_tool_names ─────────────────────────────────────────────────────────────
+
+class TestAllToolNames:
+    def test_returns_all_registered_names(
+        self, populated_registry: ToolRegistry
+    ) -> None:
+        names = set(populated_registry.all_tool_names())
+        assert names == {"read_tool", "write_tool", "dangerous_tool", "confirm_tool"}
+
+    def test_empty_registry_returns_empty_list(self) -> None:
+        assert ToolRegistry().all_tool_names() == []


### PR DESCRIPTION
## Summary

- `ToolRegistry` with `get_tools(max_permission, include_dangerous)` watermark: `READ_ONLY ≤ WRITE`; `DANGEROUS`/`REQUIRES_CONFIRMATION` excluded by default and require explicit opt-in
- `AgentLoop` gains a `confirm` hook (`Callable[[Tool, dict], Awaitable[bool]]`): `REQUIRES_CONFIRMATION` tools are blocked fail-safe when no hook is wired; callers supply the confirmation strategy
- Four WRITE-tier fix tools wrapping `CIProvider`: `GetRepoTreeTool`, `CreateBranchTool`, `UpdateFileTool`, `OpenDraftPRTool` — in the catalog now, `FixAgent` still orchestrates directly (Option A scope per design decision)
- `TriageAgent` now queries `registry.get_tools(max_permission=READ_ONLY)` instead of a hardcoded list — blast-radius ceiling is structural, not a convention to remember

## Design decisions recorded in this PR

**Q1 — Where does REQUIRES_CONFIRMATION check live?** In the loop, via a hook. Tools stay stateless; the registry stays focused on discovery; the loop is the single execution choke point. Hook = `None` → deny (fail-safe).

**Q2 — How does the registry keep write tools out of triage?** Watermark: agents declare their own ceiling (`max_permission=READ_ONLY`). The registry doesn't need to know about agent roles.

## Test plan

- [x] `tests/test_tool_registry.py` — 14 tests: registration, watermark filtering, dangerous opt-in, ordering
- [x] `tests/test_agent_loop.py::TestConfirmHook` — 4 tests: blocked with no hook, approved, denied, read-only unaffected
- [x] `tests/test_fix_tools.py` — 24 tests: all four tools, success paths, no-provider errors, provider exceptions
- [x] Full suite: 155 passed, 82.89% coverage (≥80% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)