### PR TITLE
feat(phase5): context management with ContextBudget and Strategy A compaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Accumulate operational knowledge across incidents so the agent improves over tim
 
 ---
 
-### Phase 5 — Context Management  `[ PENDING ]`
+### Phase 5 — Context Management  `[ DONE ]`
 Token budgeting and compaction for long-running investigations.
 
 **What to build:**

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ ops-pilot/
 │   ├── models.py            ← Pydantic models: Failure → Triage → Fix → Alert → MemoryRecord
 │   ├── agent_loop.py        ← Generic AgentLoop[T]: tool-use loop + Tool ABC + ToolContext + confirm hook
 │   ├── tool_registry.py     ← ToolRegistry: permission-tier watermark (READ_ONLY ≤ WRITE ≤ DANGEROUS)
+│   ├── context_budget.py    ← ContextBudget: token estimation + Strategy A compaction
 │   ├── memory_store.py      ← MemoryStore: append + weighted similarity retrieval (no external deps)
 │   ├── config.py            ← YAML config + env-var substitution + validation
 │   ├── llm_backend.py       ← LLMBackend Protocol + Anthropic / Bedrock / Vertex backends
@@ -282,6 +283,27 @@ Memory retrieval before a fast-path triage would be wasted: simple failures don'
 
 The coordinator already decides what workers to spawn and what brief to give them. Retrieving prior incidents before spawning lets that context flow into both the spawning decision and the task brief passed to each worker. The retrieval is also visible in the coordinator's initial message — auditable in Phase 7's structured log, not hidden in a system prompt.
 
+### Why does `ContextBudget` live outside `AgentLoop`, and why is it opt-in?
+
+`AgentLoop` is a generic execution engine — it shouldn't know what model it's running on or what its context limit is. Those are operational concerns owned by the entry point that constructs the agents. `ContextBudget` is injected at construction time; `AgentLoop` just calls `should_compact` and `compact` without knowing how either works.
+
+`context_budget=None` means "no budgeting" — existing call sites (tests, demo mode) are unchanged. New operational deployments in `watch_and_fix.py` wire in a budget sized for the model in use. The pattern is the same as `memory_store` on `CoordinatorAgent`: capabilities are opt-in, not forced on every caller.
+
+### Why `chars // 4` and not the Anthropic token-counting API?
+
+Token counting is for triggering a compaction decision, not for billing. The heuristic `len(all_chars) // 4` is conservative — it tends to underestimate for code and log content — so triggering at 75% of the limit absorbs the error. The Anthropic counting endpoint adds a network round-trip before every inference call, which is the wrong trade on an already-hot path. More importantly, adding a counting method to `LLMBackend` would force all three backends (Anthropic, Bedrock, Vertex) and all test mocks to implement it — a maintenance tax for an internal loop concern.
+
+### Why Strategy A (replace tool_result bodies) and not full-history summarization?
+
+By the time compaction triggers, the model has already interpreted each tool result in its subsequent assistant turn. The interpretation is load-bearing; the raw source data isn't:
+
+```
+turn N:   tool_result  → [200 lines of raw CI log]
+turn N+1: assistant    → "NPE at TokenService.validate() line 42"
+```
+
+Replacing the raw log with a stub loses nothing the model doesn't already have. Full-history summarization (Strategy B) would cost an extra LLM call on a context-stressed path, and the model summarizing its own reasoning can drop details that become relevant two turns later. Strategy B can slot in later by implementing the same `compact()` interface — the architecture supports it without changing `AgentLoop`.
+
 ### Why draft PRs, not auto-merge?
 
 ops-pilot is a force multiplier, not a replacement for engineering judgment. It opens the PR, writes the description, and notifies the team. A human reviews the diff and merges. This keeps the system useful without making it dangerous.
@@ -297,7 +319,7 @@ Raw dicts break silently when a key is missing. Pydantic validates at constructi
 No local Python install required — runs inside Docker:
 
 ```bash
-docker compose run --rm test                  # 226 tests
+docker compose run --rm test                  # 256 tests
 docker compose run --rm test pytest -k triage # single agent
 docker compose run --rm test ruff check agents/ shared/
 ```

--- a/agents/coordinator_agent.py
+++ b/agents/coordinator_agent.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 from agents.base_agent import BaseAgent
 from agents.tools.coordinator_tools import SpawnWorkerTool, build_workers
 from shared.agent_loop import AgentLoop, LoopOutcome, LoopResult, ToolContext
+from shared.context_budget import ContextBudget
 from shared.memory_store import MemoryStore
 from shared.models import AgentStatus, Failure, MemoryRecord, Severity, Triage
 
@@ -91,12 +92,14 @@ class CoordinatorAgent(BaseAgent[Triage]):
         max_turns: int = 4,
         worker_max_turns: int = 5,
         memory_store: MemoryStore | None = None,
+        context_budget: ContextBudget | None = None,
     ) -> None:
         super().__init__(backend=backend, model=model)
         self._provider = provider
         self._max_turns = max_turns
         self._worker_max_turns = worker_max_turns
         self._memory_store = memory_store
+        self._context_budget = context_budget
 
     def describe(self) -> str:
         return (
@@ -158,6 +161,7 @@ class CoordinatorAgent(BaseAgent[Triage]):
             response_model=Triage,
             model=self.model,
             max_turns=self._max_turns,
+            context_budget=self._context_budget,
         )
         ctx = ToolContext(
             provider=self._provider,

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -35,6 +35,7 @@ from shared.tool_registry import ToolRegistry
 
 if TYPE_CHECKING:
     from providers.base import CIProvider
+    from shared.context_budget import ContextBudget
 
 logger = logging.getLogger(__name__)
 
@@ -89,10 +90,12 @@ class TriageAgent(BaseAgent[Triage]):
         provider: CIProvider | None = None,
         max_turns: int = 10,
         registry: ToolRegistry | None = None,
+        context_budget: ContextBudget | None = None,
     ) -> None:
         super().__init__(backend=backend, model=model)
         self._provider = provider
         self._max_turns = max_turns
+        self._context_budget = context_budget
         if registry is None:
             registry = ToolRegistry()
             registry.register(GetFileTool())
@@ -151,6 +154,7 @@ class TriageAgent(BaseAgent[Triage]):
             response_model=Triage,
             model=self.model,
             max_turns=self._max_turns,
+            context_budget=self._context_budget,
         )
         ctx = ToolContext(
             provider=self._provider,

--- a/scripts/watch_and_fix.py
+++ b/scripts/watch_and_fix.py
@@ -35,6 +35,7 @@ from agents.fix_agent import FixAgent
 from agents.investigation_router import InvestigationRouter
 from agents.notify_agent import NotifyAgent
 from agents.triage_agent import TriageAgent
+from shared.context_budget import ContextBudget
 from shared.memory_store import MemoryStore, make_memory_record
 
 logger = logging.getLogger("ops-pilot")
@@ -67,6 +68,11 @@ def step(agent: str, msg: str, color: str = CYAN) -> None:
 
 # ── Pipeline runner ────────────────────────────────────────────────────────────
 
+# Context limit for claude-sonnet-4-6 (200k tokens). ContextBudget compacts
+# history at 75% of this — ~150k tokens — before each model call.
+_MODEL_CONTEXT_TOKENS = 200_000
+
+
 def run_pipeline(
     failure: Failure,
     pipeline: PipelineConfig,
@@ -96,16 +102,22 @@ def run_pipeline(
     except Exception:
         provider_for_triage = None
 
+    context_budget = ContextBudget(max_tokens=_MODEL_CONTEXT_TOKENS)
+
     if route == "deep":
         triage = CoordinatorAgent(
             backend=backend,
             model=cfg.model,
             provider=provider_for_triage,
             memory_store=memory_store,
+            context_budget=context_budget,
         ).run(failure)
     else:
         triage = TriageAgent(
-            backend=backend, model=cfg.model, provider=provider_for_triage
+            backend=backend,
+            model=cfg.model,
+            provider=provider_for_triage,
+            context_budget=context_budget,
         ).run(failure)
 
     # Persist incident to memory store for future similarity retrieval

--- a/shared/agent_loop.py
+++ b/shared/agent_loop.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from providers.base import CIProvider
+    from shared.context_budget import ContextBudget
     from shared.models import Failure
 
 logger = logging.getLogger(__name__)
@@ -264,6 +265,7 @@ class AgentLoop(Generic[T]):
         tool_timeout: float = 30.0,
         max_tokens: int = 4096,
         confirm: Callable[[Tool, dict], Awaitable[bool]] | None = None,
+        context_budget: ContextBudget | None = None,
     ) -> None:
         self._tools: dict[str, Tool] = {t.name: t for t in tools}
         self._confirm = confirm
@@ -273,6 +275,7 @@ class AgentLoop(Generic[T]):
         self._max_turns = max_turns
         self._tool_timeout = tool_timeout
         self._max_tokens = max_tokens
+        self._context_budget = context_budget
 
         # Full system prompt = domain instructions + loop mechanics footer.
         # The schema is embedded in the footer so the model knows the shape
@@ -303,6 +306,23 @@ class AgentLoop(Generic[T]):
 
         for turn in range(self._max_turns):
             logger.debug("AgentLoop turn %d/%d", turn + 1, self._max_turns)
+
+            # ── Step 0: Compact history if budget threshold is reached ───────
+            # Runs before the model call so the outgoing request stays within
+            # the context limit. Compaction replaces processed tool_result bodies
+            # with stubs — the model's interpretations in assistant turns are
+            # preserved. The last user message (unprocessed tool results) is
+            # always left intact.
+            if self._context_budget is not None and self._context_budget.should_compact(history):
+                before = self._context_budget._estimate_tokens(history)
+                history = self._context_budget.compact(history)
+                after = self._context_budget._estimate_tokens(history)
+                logger.info(
+                    "AgentLoop: compacted history at turn %d — %d→%d estimated tokens",
+                    turn + 1,
+                    before,
+                    after,
+                )
 
             # ── Step 1: Call the model ───────────────────────────────────────
             # Pass list(history) — a snapshot — not the mutable history reference.

--- a/shared/context_budget.py
+++ b/shared/context_budget.py
@@ -1,0 +1,176 @@
+"""Context budget management for AgentLoop.
+
+Tracks estimated token usage across a conversation and compacts the message
+history when usage approaches the model's context limit.
+
+Compaction strategy (Strategy A):
+  Replace the body of already-processed tool_result messages with a compact
+  stub. The model's interpretation of those results — in the subsequent
+  assistant turn — is load-bearing. The raw source data is not.
+
+  turn N:   tool_result  → [200 lines of raw CI log]
+  turn N+1: assistant    → "NPE at TokenService.validate() line 42"
+
+  After turn N+1, the 200-line log is dead weight. The stub records that
+  compaction happened so the model understands why the raw data is absent.
+
+  Error tool results are never compacted — they are already short, and the
+  model may need the error text to adapt its investigation strategy.
+
+  The last user message in history is never compacted — it contains the most
+  recent tool results which the model has not yet processed.
+
+Token estimation:
+  len(all_text_chars) // 4  — conservative heuristic, no network round-trip,
+  no dependency on the LLM backend. Tends to underestimate for code and log
+  content (shorter average token length), so triggering at 75% of the limit
+  gives adequate headroom to absorb the heuristic error.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MIN_THRESHOLD = 0.60   # floor: never compact at < 60% of limit
+_MAX_THRESHOLD = 1.0
+
+
+class ContextBudget:
+    """Token budget and compaction strategy for a single AgentLoop run.
+
+    Args:
+        max_tokens:           Model context limit in tokens. Sets the ceiling
+                              against which usage is measured.
+        compaction_threshold: Fraction of max_tokens at which compaction
+                              triggers. Default 0.75. Must be in [0.60, 1.0].
+                              Lower values = more aggressive compaction.
+
+    Raises:
+        ValueError: If compaction_threshold is outside [0.60, 1.0].
+    """
+
+    def __init__(
+        self,
+        max_tokens: int,
+        compaction_threshold: float = 0.75,
+    ) -> None:
+        if not (_MIN_THRESHOLD <= compaction_threshold <= _MAX_THRESHOLD):
+            raise ValueError(
+                f"compaction_threshold must be in [{_MIN_THRESHOLD}, {_MAX_THRESHOLD}], "
+                f"got {compaction_threshold}"
+            )
+        self._max_tokens = max_tokens
+        self._threshold = compaction_threshold
+        self._trigger_at = int(max_tokens * compaction_threshold)
+
+    @property
+    def max_tokens(self) -> int:
+        """The model context limit this budget was created for."""
+        return self._max_tokens
+
+    @property
+    def compaction_threshold(self) -> float:
+        """Fraction of max_tokens at which compaction triggers."""
+        return self._threshold
+
+    def should_compact(self, messages: list[dict]) -> bool:
+        """Return True if estimated token usage meets or exceeds the trigger threshold.
+
+        Args:
+            messages: Current conversation history.
+
+        Returns:
+            True if compaction should run before the next model call.
+        """
+        return self._estimate_tokens(messages) >= self._trigger_at
+
+    def compact(self, messages: list[dict]) -> list[dict]:
+        """Replace processed tool_result bodies with compact stubs.
+
+        Leaves untouched:
+          - The last user message (model has not yet processed its tool results)
+          - Error tool results (short; model may need the error text)
+          - Assistant messages (contain the load-bearing interpretations)
+          - User messages with string content (initial messages, not tool results)
+
+        Args:
+            messages: Conversation history to compact.
+
+        Returns:
+            New list with compacted tool_result blocks. The input is not mutated.
+        """
+        # Identify the last user message — preserve it intact
+        last_user_idx: int | None = None
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
+
+        compacted: list[dict] = []
+        compacted_count = 0
+
+        for i, msg in enumerate(messages):
+            # Non-user messages and the last user message pass through unchanged
+            if msg.get("role") != "user" or i == last_user_idx:
+                compacted.append(msg)
+                continue
+
+            content = msg.get("content", "")
+            if not isinstance(content, list):
+                # String-content user message (e.g. initial prompt) — pass through
+                compacted.append(msg)
+                continue
+
+            new_content: list[dict] = []
+            for block in content:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") == "tool_result"
+                    and not block.get("is_error")
+                ):
+                    raw_chars = len(str(block.get("content", "")))
+                    new_content.append({
+                        **block,
+                        "content": (
+                            f"[compacted: {raw_chars} chars of tool output — "
+                            "key findings extracted in subsequent assistant turn]"
+                        ),
+                    })
+                    compacted_count += 1
+                else:
+                    new_content.append(block)
+
+            compacted.append({**msg, "content": new_content})
+
+        if compacted_count:
+            logger.debug(
+                "ContextBudget: compacted %d tool result(s)", compacted_count
+            )
+        return compacted
+
+    @staticmethod
+    def _estimate_tokens(messages: list[dict]) -> int:
+        """Estimate token count from total character length.
+
+        Uses the heuristic: 1 token ≈ 4 characters (rough average for English
+        prose). For code and log content, actual token density is higher, so
+        this underestimates — the compaction_threshold provides the buffer.
+
+        Args:
+            messages: Conversation history (any nesting depth).
+
+        Returns:
+            Estimated token count. Always ≥ 0.
+        """
+        def _count_chars(obj: object) -> int:
+            if isinstance(obj, str):
+                return len(obj)
+            if isinstance(obj, dict):
+                return sum(_count_chars(v) for v in obj.values())
+            if isinstance(obj, list):
+                return sum(_count_chars(item) for item in obj)
+            return 0  # int, bool, None — negligible
+
+        return _count_chars(messages) // 4

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,340 @@
+"""Tests for shared/context_budget.py.
+
+Testing strategy:
+  - _estimate_tokens is a pure static method — tested exhaustively across all
+    message content structures (string, list, nested dict).
+  - should_compact is a pure function of estimate vs threshold — tested at the
+    boundary exactly.
+  - compact covers all the structural cases: non-user messages unchanged,
+    last user message preserved, earlier tool_results compacted, error results
+    preserved, string-content user messages pass through.
+  - Constructor validation tests the threshold floor.
+  - Integration: AgentLoop tests verify that the budget is invoked at the right
+    point in the loop lifecycle and that None budget leaves existing behaviour
+    unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.context_budget import ContextBudget
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _tool_result_msg(content: str, is_error: bool = False) -> dict:
+    block: dict = {"type": "tool_result", "tool_use_id": "toolu_01", "content": content}
+    if is_error:
+        block["is_error"] = True
+    return {"role": "user", "content": [block]}
+
+
+def _assistant_msg(text: str) -> dict:
+    return {"role": "assistant", "content": [{"type": "text", "text": text}]}
+
+
+def _initial_user_msg(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+# ── _estimate_tokens ───────────────────────────────────────────────────────────
+
+class TestEstimateTokens:
+    def test_empty_list_returns_zero(self) -> None:
+        assert ContextBudget._estimate_tokens([]) == 0
+
+    def test_string_content_message(self) -> None:
+        # 400 chars of content + small overhead from "role"/"user" keys = ~101 tokens
+        msgs = [{"role": "user", "content": "a" * 400}]
+        estimate = ContextBudget._estimate_tokens(msgs)
+        assert 100 <= estimate <= 105
+
+    def test_list_content_text_block(self) -> None:
+        # 800 chars of text + small overhead from role/type strings = ~203 tokens
+        msgs = [{"role": "assistant", "content": [{"type": "text", "text": "a" * 800}]}]
+        estimate = ContextBudget._estimate_tokens(msgs)
+        assert 200 <= estimate <= 210
+
+    def test_tool_result_block_counted(self) -> None:
+        msgs = [_tool_result_msg("a" * 4000)]
+        # content key contributes 4000 chars, so 1000 tokens minimum
+        assert ContextBudget._estimate_tokens(msgs) >= 1000
+
+    def test_multiple_messages_summed(self) -> None:
+        msgs = [
+            _initial_user_msg("a" * 400),   # 100 tokens
+            _assistant_msg("b" * 400),       # 100 tokens
+        ]
+        estimate = ContextBudget._estimate_tokens(msgs)
+        # Must be at least 200 (the two content strings)
+        assert estimate >= 200
+
+    def test_deeply_nested_dict_counted(self) -> None:
+        msgs = [{"role": "user", "content": [{"type": "tool_use", "input": {"key": "a" * 400}}]}]
+        assert ContextBudget._estimate_tokens(msgs) >= 100
+
+    def test_non_string_values_ignored(self) -> None:
+        """Ints, bools, None in dicts contribute 0."""
+        msgs = [{"role": "user", "content": [{"type": "tool_result", "is_error": False, "content": ""}]}]
+        # Should not raise, and should return a non-negative value
+        assert ContextBudget._estimate_tokens(msgs) >= 0
+
+
+# ── should_compact ─────────────────────────────────────────────────────────────
+
+class TestShouldCompact:
+    def test_below_threshold_returns_false(self) -> None:
+        budget = ContextBudget(max_tokens=1000, compaction_threshold=0.75)
+        # trigger at 750 tokens; 400 chars / 4 = 100 tokens
+        msgs = [_initial_user_msg("a" * 400)]
+        assert budget.should_compact(msgs) is False
+
+    def test_at_threshold_returns_true(self) -> None:
+        budget = ContextBudget(max_tokens=100, compaction_threshold=0.75)
+        # trigger at 75 tokens; exactly 300 chars = 75 tokens
+        msgs = [_initial_user_msg("a" * 300)]
+        assert budget.should_compact(msgs) is True
+
+    def test_above_threshold_returns_true(self) -> None:
+        budget = ContextBudget(max_tokens=100, compaction_threshold=0.75)
+        msgs = [_initial_user_msg("a" * 400)]  # 100 tokens > 75 trigger
+        assert budget.should_compact(msgs) is True
+
+    def test_empty_messages_never_compacts(self) -> None:
+        budget = ContextBudget(max_tokens=100, compaction_threshold=0.75)
+        assert budget.should_compact([]) is False
+
+
+# ── compact ────────────────────────────────────────────────────────────────────
+
+class TestCompact:
+    def test_replaces_tool_result_content_with_stub(self) -> None:
+        budget = ContextBudget(max_tokens=1000)
+        history = [
+            _initial_user_msg("investigate this"),
+            _assistant_msg("calling tool"),
+            _tool_result_msg("a" * 500),   # first user msg — should be compacted
+            _assistant_msg("found root cause"),
+            _tool_result_msg("b" * 500),   # last user msg — should NOT be compacted
+        ]
+        result = budget.compact(history)
+        # Third message (index 2) — first tool result — should be compacted
+        compacted_block = result[2]["content"][0]
+        assert "[compacted:" in compacted_block["content"]
+        assert "500" in compacted_block["content"]
+
+    def test_preserves_last_user_message_intact(self) -> None:
+        budget = ContextBudget(max_tokens=1000)
+        raw_content = "b" * 500
+        history = [
+            _tool_result_msg("a" * 500),   # earlier — compacted
+            _tool_result_msg(raw_content),  # last — preserved
+        ]
+        result = budget.compact(history)
+        last_block = result[-1]["content"][0]
+        assert last_block["content"] == raw_content  # unchanged
+
+    def test_preserves_error_tool_results(self) -> None:
+        budget = ContextBudget(max_tokens=1000)
+        error_content = "Tool failed: connection refused"
+        history = [
+            _initial_user_msg("start"),
+            _assistant_msg("calling tool"),
+            _tool_result_msg(error_content, is_error=True),  # error — preserved even if not last
+            _assistant_msg("handling error"),
+            _tool_result_msg("x" * 500),  # last user msg
+        ]
+        result = budget.compact(history)
+        # Error result at index 2 — must be preserved
+        error_block = result[2]["content"][0]
+        assert error_block["content"] == error_content
+
+    def test_preserves_assistant_messages(self) -> None:
+        budget = ContextBudget(max_tokens=1000)
+        assistant_text = "Root cause: null pointer at line 42"
+        history = [
+            _tool_result_msg("a" * 500),
+            _assistant_msg(assistant_text),
+            _tool_result_msg("b" * 500),
+        ]
+        result = budget.compact(history)
+        assert result[1]["content"][0]["text"] == assistant_text
+
+    def test_string_content_user_message_passes_through(self) -> None:
+        """Initial user message with string content is never modified."""
+        budget = ContextBudget(max_tokens=1000)
+        text = "investigate this failure"
+        history = [
+            _initial_user_msg(text),
+            _tool_result_msg("b" * 500),
+        ]
+        result = budget.compact(history)
+        assert result[0]["content"] == text
+
+    def test_multiple_tool_results_all_but_last_compacted(self) -> None:
+        budget = ContextBudget(max_tokens=1000)
+        history = [
+            _tool_result_msg("first call result"),
+            _assistant_msg("thinking..."),
+            _tool_result_msg("second call result"),
+            _assistant_msg("thinking more..."),
+            _tool_result_msg("third call result"),  # last — preserved
+        ]
+        result = budget.compact(history)
+        assert "[compacted:" in result[0]["content"][0]["content"]
+        assert "[compacted:" in result[2]["content"][0]["content"]
+        assert result[4]["content"][0]["content"] == "third call result"
+
+    def test_input_list_not_mutated(self) -> None:
+        budget = ContextBudget(max_tokens=1000)
+        history = [
+            _tool_result_msg("a" * 500),
+            _tool_result_msg("b" * 500),
+        ]
+        original_content = history[0]["content"][0]["content"]
+        budget.compact(history)
+        # Original must be unchanged
+        assert history[0]["content"][0]["content"] == original_content
+
+    def test_empty_history_returns_empty(self) -> None:
+        budget = ContextBudget(max_tokens=1000)
+        assert budget.compact([]) == []
+
+    def test_single_user_message_preserved(self) -> None:
+        """Single message is the 'last user message' — never compacted."""
+        budget = ContextBudget(max_tokens=1000)
+        history = [_tool_result_msg("only message")]
+        result = budget.compact(history)
+        assert result[0]["content"][0]["content"] == "only message"
+
+    def test_compaction_reduces_token_estimate(self) -> None:
+        """After compaction, estimated tokens should be lower."""
+        budget = ContextBudget(max_tokens=1000)
+        history = [
+            _tool_result_msg("a" * 2000),
+            _assistant_msg("found it"),
+            _tool_result_msg("b" * 2000),  # last — preserved
+        ]
+        before = ContextBudget._estimate_tokens(history)
+        compacted = budget.compact(history)
+        after = ContextBudget._estimate_tokens(compacted)
+        assert after < before
+
+
+# ── Constructor validation ─────────────────────────────────────────────────────
+
+class TestConstructorValidation:
+    def test_valid_threshold_accepted(self) -> None:
+        budget = ContextBudget(max_tokens=200_000, compaction_threshold=0.75)
+        assert budget.compaction_threshold == 0.75
+
+    def test_minimum_threshold_accepted(self) -> None:
+        ContextBudget(max_tokens=100_000, compaction_threshold=0.60)  # no error
+
+    def test_maximum_threshold_accepted(self) -> None:
+        ContextBudget(max_tokens=100_000, compaction_threshold=1.0)  # no error
+
+    def test_below_minimum_raises(self) -> None:
+        with pytest.raises(ValueError, match="compaction_threshold"):
+            ContextBudget(max_tokens=100_000, compaction_threshold=0.59)
+
+    def test_above_maximum_raises(self) -> None:
+        with pytest.raises(ValueError, match="compaction_threshold"):
+            ContextBudget(max_tokens=100_000, compaction_threshold=1.01)
+
+    def test_properties_accessible(self) -> None:
+        budget = ContextBudget(max_tokens=50_000, compaction_threshold=0.80)
+        assert budget.max_tokens == 50_000
+        assert budget.compaction_threshold == 0.80
+
+
+# ── AgentLoop integration ──────────────────────────────────────────────────────
+
+class TestAgentLoopIntegration:
+    """Verify ContextBudget is invoked at the right point in AgentLoop.run()."""
+
+    def _make_end_turn_response(self, text: str = "done"):
+        import types
+        block = types.SimpleNamespace(type="text", text=text)
+        return types.SimpleNamespace(content=[block])
+
+    def _make_backend(self, responses):
+        from unittest.mock import MagicMock
+        backend = MagicMock()
+        backend.complete_with_tools.side_effect = responses
+        backend.complete.return_value = '{"output": "done", "severity": "low", "affected_service": "auth", "regression_introduced_in": "abc", "fix_confidence": "HIGH"}'
+        return backend
+
+    def test_no_budget_loop_runs_normally(self) -> None:
+        """context_budget=None leaves existing loop behaviour unchanged."""
+        from unittest.mock import MagicMock
+
+        from shared.agent_loop import AgentLoop, ToolContext
+        from shared.models import Triage
+
+        backend = self._make_backend([self._make_end_turn_response()])
+        loop: AgentLoop[Triage] = AgentLoop(
+            tools=[],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Triage,
+            model="test-model",
+            context_budget=None,
+        )
+        import asyncio
+        ctx = ToolContext(provider=None, failure=MagicMock())
+        result = asyncio.run(loop.run(messages=[{"role": "user", "content": "go"}], ctx=ctx))
+        assert result.turns_used == 1
+
+    def test_budget_triggers_compaction_when_threshold_met(self) -> None:
+        """When budget.should_compact returns True, compact() is applied."""
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from shared.agent_loop import AgentLoop, ToolContext
+        from shared.models import Triage
+
+        backend = self._make_backend([self._make_end_turn_response()])
+        # Budget that always triggers
+        budget = ContextBudget(max_tokens=1, compaction_threshold=0.60)
+
+        with patch.object(ContextBudget, "should_compact", return_value=True) as mock_should, \
+             patch.object(ContextBudget, "compact", wraps=budget.compact) as mock_compact:
+            loop: AgentLoop[Triage] = AgentLoop(
+                tools=[],
+                backend=backend,
+                domain_system_prompt="test",
+                response_model=Triage,
+                model="test-model",
+                context_budget=budget,
+            )
+            ctx = ToolContext(provider=None, failure=MagicMock())
+            asyncio.run(loop.run(messages=[{"role": "user", "content": "go"}], ctx=ctx))
+
+        mock_should.assert_called()
+        mock_compact.assert_called()
+
+    def test_budget_not_applied_when_below_threshold(self) -> None:
+        """When budget.should_compact returns False, compact() is not called."""
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from shared.agent_loop import AgentLoop, ToolContext
+        from shared.models import Triage
+
+        backend = self._make_backend([self._make_end_turn_response()])
+        budget = ContextBudget(max_tokens=200_000, compaction_threshold=0.75)
+
+        with patch.object(ContextBudget, "compact", wraps=budget.compact) as mock_compact:
+            loop: AgentLoop[Triage] = AgentLoop(
+                tools=[],
+                backend=backend,
+                domain_system_prompt="test",
+                response_model=Triage,
+                model="test-model",
+                context_budget=budget,
+            )
+            ctx = ToolContext(provider=None, failure=MagicMock())
+            asyncio.run(loop.run(messages=[{"role": "user", "content": "short message"}], ctx=ctx))
+
+        mock_compact.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `ContextBudget(max_tokens, compaction_threshold=0.75)` — token estimation + Strategy A message compaction, zero external deps
- `AgentLoop` accepts `context_budget: ContextBudget | None = None` (opt-in — `None` preserves existing behaviour exactly)
- Compaction check runs at the start of each turn (Step 0), before the model call: replaces processed tool_result bodies with stubs; leaves the last user message, error results, and assistant turns untouched
- `watch_and_fix.py` constructs `ContextBudget(max_tokens=200_000)` and injects it into both `TriageAgent` and `CoordinatorAgent` — agents don't know their own context limit (operational concern owned by the entry point)
- Threshold floor of 0.60 enforced at construction time; default 0.75 gives ~25% headroom to absorb heuristic underestimation for code/log content

## Test plan

- [ ] 30 new tests in `test_context_budget.py`: `_estimate_tokens` coverage across all message structures, `should_compact` boundary conditions, `compact` structural cases (last user msg preserved, error results preserved, assistant turns unchanged, input not mutated), constructor validation, `AgentLoop` integration (budget invoked, not invoked below threshold)
- [ ] 256 total tests pass, 84.67% coverage, `context_budget.py` at 100%
- [ ] Lint clean on `agents/ shared/ tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)