### PR TITLE
feat(phase7): Trust & Explainability Layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ venv311/
 
 # Usage tracking (per-deployment runtime data)
 usage/
+
+# Audit trail (per-deployment runtime data)
+audit/

--- a/README.md
+++ b/README.md
@@ -81,16 +81,30 @@ flowchart LR
     A["💥 CI Failure\nGitHub · GitLab · Jenkins"] --> B
 
     subgraph agents ["ops-pilot agents"]
-        direction LR
+        direction TB
         B["👁 Monitor\npolls for failures"] --> C["🔍 Triage\nroot cause + severity"]
-        C --> D["🔧 Fix\npatch + draft PR"]
-        D --> E["🔔 Notify\nSlack message"]
+        C -->|"fix_confidence\n≥ MEDIUM"| D["🔧 Fix\npatch + draft PR"]
+        C -->|"fix_confidence\n= LOW"| ESC["⚠️ Escalate\nhuman review summary"]
+        D --> E["🔔 Notify\nfix-ready alert"]
+        ESC --> E2["🔔 Notify\nhuman-review alert"]
     end
 
     C <--> F["☁️ LLM Backend\nAnthropic · Bedrock · Vertex AI"]
     D <--> F
+    ESC <--> F
+
+    subgraph trust ["🔐 Trust layer (every tool call)"]
+        direction LR
+        T1["📋 Audit log\nJSONL per day"] 
+        T2["💬 Pre-action\nexplanation"]
+    end
+
+    D -.->|"REQUIRES_CONFIRMATION\ntools"| T2
+    D -.-> T1
+    C -.-> T1
 
     E --> G["📬 Slack / console"]
+    E2 --> G
     D --> H["🔀 Draft PR\nhuman reviews & merges"]
 ```
 
@@ -99,9 +113,11 @@ flowchart LR
 | Step | Agent | What it does |
 |------|-------|-------------|
 | 1 | **Monitor** | Polls GitHub Actions / GitLab CI / Jenkins every 30s. Finds new failed runs, fetches log output. |
-| 2 | **Triage** | Runs an agentic tool-use loop: reads source files, fetches earlier log sections, diffs commits — until it has enough signal to conclude. Returns root cause, severity (LOW→CRITICAL), affected service, and fix confidence. If confidence is LOW at turn limit, escalates to human instead of guessing. |
-| 3 | **Fix** | Asks Claude which files to change and how. Commits the patch to `ops-pilot/fix-<sha>`, opens a **draft** PR. Nothing merges without a human. |
-| 4 | **Notify** | Posts a one-paragraph Slack summary: what broke, why, and a link to the PR. Falls back to console output in dev mode. |
+| 2 | **Triage** | Runs an agentic tool-use loop: reads source files, fetches earlier log sections, diffs commits — until it has enough signal to conclude. Returns root cause, severity (LOW→CRITICAL), affected service, and fix confidence. |
+| 3 | **Fix or Escalate** | If confidence is MEDIUM or HIGH: commits a patch and opens a draft PR. If confidence is LOW: generates an escalation summary (what was investigated, what was inconclusive, recommended next step) — no PR is opened; a human is required. |
+| 4 | **Notify** | Posts a one-paragraph Slack summary: fix-ready alert with PR link, or escalation alert requesting human review. Falls back to console in dev mode. |
+
+Every tool call (file reads, commits, PR opens) is written to a structured JSONL audit log. Destructive tools (`update_file`, `open_draft_pr`) get a pre-action LLM explanation generated before execution — observable without blocking.
 
 **Deduplication:** ops-pilot uses open GitHub/GitLab PRs as its source of truth. If a PR for a commit already exists, it waits — it will never spam your repo with duplicate PRs, even after a crash or redeploy.
 
@@ -121,7 +137,7 @@ ops-pilot/
 │   ├── notify_agent.py         ← Slack / webhook / console notification
 │   └── tools/
 │       ├── triage_tools.py     ← GetFileTool, GetMoreLogTool, GetCommitDiffTool (READ_ONLY)
-│       ├── fix_tools.py        ← GetRepoTreeTool, CreateBranchTool, UpdateFileTool, OpenDraftPRTool (WRITE)
+│       ├── fix_tools.py        ← GetRepoTreeTool, CreateBranchTool (WRITE); UpdateFileTool, OpenDraftPRTool (REQUIRES_CONFIRMATION)
 │       └── coordinator_tools.py ← SpawnWorkerTool + LogWorker / SourceWorker / DiffWorker
 ├── providers/
 │   ├── base.py              ← CIProvider ABC (7 methods: get_failures, open_draft_pr, …)
@@ -132,13 +148,20 @@ ops-pilot/
 ├── shared/
 │   ├── models.py            ← Pydantic models: Failure → Triage → Fix → Alert → MemoryRecord
 │   ├── agent_loop.py        ← Generic AgentLoop[T]: tool-use loop + Tool ABC + ToolContext + confirm hook
-│   ├── tool_registry.py     ← ToolRegistry: permission-tier watermark (READ_ONLY ≤ WRITE ≤ DANGEROUS)
+│   ├── tool_registry.py     ← ToolRegistry: permission-tier watermark (READ_ONLY ≤ WRITE ≤ DANGEROUS ≤ REQUIRES_CONFIRMATION)
 │   ├── context_budget.py    ← ContextBudget: token estimation + Strategy A compaction
 │   ├── memory_store.py      ← MemoryStore: append + weighted similarity retrieval (no external deps)
-│   ├── config.py            ← YAML config + env-var substitution + validation
+│   ├── config.py            ← YAML config + env-var substitution + Pydantic validation (TrustConfig, RateLimitsConfig, PermissionsConfig)
 │   ├── llm_backend.py       ← LLMBackend Protocol + Anthropic / Bedrock / Vertex backends
 │   ├── task_queue.py        ← File-locked task queue (atomic rename, no broker needed)
-│   └── state_store.py       ← JSON state (dedup across restarts)
+│   ├── state_store.py       ← JSON state (dedup across restarts)
+│   ├── tenant_context.py    ← TenantContext: per-deployment identity, usage tracker, tool permissions
+│   ├── rate_limiter.py      ← RateLimiter: sliding-window API call + token limits per tenant
+│   ├── usage_tracker.py     ← UsageTracker: per-tenant API call / token / incident counters
+│   ├── audit_log.py         ← AuditLog: one JSONL record per tool call, per-day rotation, atomic writes
+│   ├── explanation_gen.py   ← ExplanationGenerator: pre-action LLM explanation for REQUIRES_CONFIRMATION tools
+│   ├── escalation.py        ← EscalationSummary + generate_escalation_summary (LOW-confidence path)
+│   └── trust_context.py     ← TrustContext dataclass + make_trust_context factory
 ├── demo/
 │   ├── app.py               ← FastAPI SSE server for local demo
 │   ├── scenarios/           ← 3 pre-recorded realistic failure scenarios (JSON)
@@ -148,18 +171,26 @@ ops-pilot/
 │   ├── demo.gif             ← Animated walkthrough embedded in README
 │   └── scenarios/           ← Scenario JSON files served statically
 ├── tests/
-│   ├── conftest.py          ← Shared fixtures (sample_failure, mock_backend, …)
+│   ├── conftest.py                 ← Shared fixtures (sample_failure, mock_backend, …)
 │   ├── test_triage_agent.py
 │   ├── test_coordinator_agent.py
 │   ├── test_investigation_router.py
 │   ├── test_memory_store.py
 │   ├── test_fix_agent.py
+│   ├── test_fix_tools.py
 │   ├── test_notify_agent.py
 │   ├── test_monitor_agent.py
 │   ├── test_llm_client.py
 │   ├── test_state_store.py
 │   ├── test_task_queue.py
-│   └── fixtures/            ← Sample CI log files
+│   ├── test_agent_loop.py          ← AgentLoop + TrustContext integration tests
+│   ├── test_audit_log.py
+│   ├── test_explanation_gen.py
+│   ├── test_escalation.py
+│   ├── test_trust_context.py
+│   ├── test_tenant_context.py
+│   ├── test_rate_limiter.py
+│   └── fixtures/                   ← Sample CI log files
 ├── .claude/commands/        ← 5 Claude Code slash commands (see below)
 ├── memory/                  ← Incident memory (created at runtime)
 │   ├── incidents/           ← One JSON file per incident
@@ -304,6 +335,34 @@ turn N+1: assistant    → "NPE at TokenService.validate() line 42"
 
 Replacing the raw log with a stub loses nothing the model doesn't already have. Full-history summarization (Strategy B) would cost an extra LLM call on a context-stressed path, and the model summarizing its own reasoning can drop details that become relevant two turns later. Strategy B can slot in later by implementing the same `compact()` interface — the architecture supports it without changing `AgentLoop`.
 
+### Why per-deployment isolation instead of a runtime tenant switcher?
+
+`TenantContext` is constructed once at startup from the config file and injected into every agent. This means the deployment model is "one config file = one customer" — isolated processes, isolated state, isolated usage tracking. A bug in Customer A's pipeline cannot reach Customer B's memory or rate limit counters.
+
+The alternative — a shared process with a `tenant_id` routing key — would require every data store (memory, state, audit log) to be partitioned by tenant ID, and every agent to filter carefully. One missed filter = data leak. For an agentic system that writes files and opens PRs, the blast radius of a data-routing mistake is unacceptably high. Process isolation is boring and correct.
+
+### Why is `RateLimiter` a sliding window, not a fixed bucket?
+
+A fixed 1-hour bucket resets on the clock: a deployment could use its entire hourly quota in the last 10 minutes of the hour, then the full quota again in the first 10 minutes of the next — 200% in 20 minutes with no rate limit applied. A sliding window (per-call timestamps in a deque) means "at most N calls in any 60-minute window," which is what operators actually want when they say "1000 calls per hour."
+
+### Why a structured JSONL audit log instead of application logs?
+
+Application logs are for debugging; audit logs are for accountability. The difference: application logs are prose consumed by developers after a crash. Audit logs are structured records consumed by compliance tooling, dashboards, and incident reviewers after a breach or unexpected action.
+
+JSONL (one JSON object per line) makes the audit trail grep-friendly and ingestible by any log pipeline (CloudWatch, Datadog, Splunk) without a parser. Rotating by day (`audit/YYYY-MM-DD.jsonl`) bounds file size and maps naturally to retention policies ("keep 90 days"). Atomic writes (`mkstemp` + `rename`) prevent partial records if the process dies mid-write.
+
+### Why does `REQUIRES_CONFIRMATION` auto-proceed when `TrustContext` is present?
+
+Phase 7 is an *observability layer*, not an approval gate. The pre-action explanation is generated so that the audit log contains a human-readable record of *why* the agent decided to commit a file or open a PR — not to block the action waiting for a human click.
+
+Blocking confirmation (`Phase 8`) changes the system from "AI takes action, humans can audit" to "AI proposes action, human approves before execution." That's a fundamentally different product (and deployment model). Phase 7 establishes the explanation infrastructure that Phase 8 will reuse — the `confirm` hook in `AgentLoop` is already the extension point for that upgrade.
+
+### Why generate an escalation summary instead of returning LOW-confidence triage directly?
+
+A LOW-confidence `Triage` says "I'm not sure." An `EscalationSummary` says "here's what I investigated, here's what I couldn't pin down, and here's what you should do next." That's the difference between an alert that pages an engineer at 2 AM and makes them dig through the same evidence the agent already processed, versus an alert that hands off a structured investigation brief.
+
+The escalation summary is also what gets sent to Slack — engineers see a purpose-built "human review required" message, not a raw Triage object with `fix_confidence: LOW` that requires them to know what that field means.
+
 ### Why draft PRs, not auto-merge?
 
 ops-pilot is a force multiplier, not a replacement for engineering judgment. It opens the PR, writes the description, and notifies the team. A human reviews the diff and merges. This keeps the system useful without making it dangerous.
@@ -319,7 +378,7 @@ Raw dicts break silently when a key is missing. Pydantic validates at constructi
 No local Python install required — runs inside Docker:
 
 ```bash
-docker compose run --rm test                  # 256 tests
+docker compose run --rm test                  # 335 tests
 docker compose run --rm test pytest -k triage # single agent
 docker compose run --rm test ruff check agents/ shared/
 ```

--- a/README.md
+++ b/README.md
@@ -77,35 +77,73 @@ pipelines:
 ## How it works
 
 ```mermaid
-flowchart LR
-    A["💥 CI Failure\nGitHub · GitLab · Jenkins"] --> B
+flowchart TB
+    CI["💥 CI Failure\nGitHub · GitLab · Jenkins"] --> MON
 
-    subgraph agents ["ops-pilot agents"]
+    subgraph pipeline ["ops-pilot pipeline"]
         direction TB
-        B["👁 Monitor\npolls for failures"] --> C["🔍 Triage\nroot cause + severity"]
-        C -->|"fix_confidence\n≥ MEDIUM"| D["🔧 Fix\npatch + draft PR"]
-        C -->|"fix_confidence\n= LOW"| ESC["⚠️ Escalate\nhuman review summary"]
-        D --> E["🔔 Notify\nfix-ready alert"]
-        ESC --> E2["🔔 Notify\nhuman-review alert"]
+        MON["👁 MonitorAgent\npolls every 30 s"]
+        MON --> ROUTE["🔀 InvestigationRouter  · Phase 3\nfiles changed · diff size · log length"]
+
+        subgraph triage ["Triage — fast or deep path  · Phase 3"]
+            direction TB
+            ROUTE -->|"simple failure\nsmall diff / short log"| FAST["🔍 TriageAgent\nfast path"]
+            ROUTE -->|"complex failure\nlarge diff / rich log"| COORD["🧠 CoordinatorAgent\ndeep path"]
+            subgraph workers ["Parallel specialist workers  · Phase 3"]
+                direction LR
+                WL["📋 LogWorker\nfetches log sections"]
+                WS["📁 SourceWorker\nreads source files"]
+                WD["🔍 DiffWorker\nreads full diff hunks"]
+            end
+            COORD <-->|"spawns via\nSpawnWorkerTool"| workers
+        end
+
+        FAST --> GATE{fix_confidence?}
+        COORD --> GATE
+        GATE -->|"HIGH / MEDIUM"| FIX["🔧 FixAgent\npatch + draft PR"]
+        GATE -->|"LOW"| ESC["⚠️ EscalationSummary\nhuman review brief"]
+        FIX --> NFIX["🔔 NotifyAgent\nfix-ready alert"]
+        ESC --> NESC["🔔 NotifyAgent\nhuman-review alert"]
     end
 
-    C <--> F["☁️ LLM Backend\nAnthropic · Bedrock · Vertex AI"]
-    D <--> F
-    ESC <--> F
-
-    subgraph trust ["🔐 Trust layer (every tool call)"]
+    subgraph loop ["🔁 AgentLoop — shared execution engine  · Phases 1 & 2"]
         direction LR
-        T1["📋 Audit log\nJSONL per day"] 
-        T2["💬 Pre-action\nexplanation"]
+        REG["ToolRegistry\nREAD_ONLY · WRITE\nREQUIRES_CONFIRMATION · DANGEROUS"]
+        BUD["ContextBudget  · Phase 5\ntoken estimation · Strategy A compaction"]
     end
 
-    D -.->|"REQUIRES_CONFIRMATION\ntools"| T2
-    D -.-> T1
-    C -.-> T1
+    FAST & COORD & workers & FIX -.->|"each runs via"| loop
 
-    E --> G["📬 Slack / console"]
-    E2 --> G
-    D --> H["🔀 Draft PR\nhuman reviews & merges"]
+    MEM["📚 MemoryStore  · Phase 4\nweighted similarity retrieval\nweekly consolidation job"]
+    COORD -->|"retrieve similar\npast incidents"| MEM
+    pipeline -.->|"save incident\npost-resolution"| MEM
+
+    subgraph trust ["🔐 TrustContext  · Phase 7"]
+        direction LR
+        AUD["📋 AuditLog\none JSONL record per tool call\nper-day rotation · atomic writes"]
+        EXP["💬 ExplanationGenerator\nLLM reasoning before\nREQUIRES_CONFIRMATION tools"]
+    end
+
+    loop -.->|"every tool call"| AUD
+    loop -.->|"before write tools"| EXP
+
+    subgraph tenancy ["🏢 TenantContext  · Phase 6"]
+        direction LR
+        TID["Identity\ntenant_id · actor"]
+        PRM["PermissionsConfig\ntool allowlist"]
+        RLM["RateLimiter\nsliding window"]
+        UTK["UsageTracker\nAPI calls · tokens · incidents"]
+    end
+
+    tenancy -.->|"injected into every agent at startup"| pipeline
+
+    LLM["☁️ LLM Backend\nAnthropic · AWS Bedrock · Google Vertex AI"]
+    loop <-->|"complete_with_tools()\ncomplete()"| LLM
+    ESC <-->|"generate_escalation_summary()"| LLM
+    NFIX & NESC <-->|"generate Slack message"| LLM
+
+    NFIX & NESC --> SLACK["📬 Slack / console"]
+    FIX --> PR["🔀 Draft PR\nhuman reviews & merges"]
 ```
 
 ### The 30-second version

--- a/agents/notify_agent.py
+++ b/agents/notify_agent.py
@@ -20,6 +20,7 @@ from datetime import datetime
 import httpx
 
 from agents.base_agent import BaseAgent
+from shared.escalation import EscalationSummary
 from shared.models import AgentStatus, Alert, Failure, Fix, Severity, Triage
 
 logger = logging.getLogger(__name__)
@@ -80,22 +81,44 @@ class NotifyAgent(BaseAgent[Alert]):
         """Return a one-line description of this agent's responsibility."""
         return "Sends Slack alerts with triage summary and PR link when a fix is ready"
 
-    def run(self, failure: Failure, triage: Triage, fix: Fix) -> Alert:
+    def run(
+        self,
+        failure: Failure,
+        triage: Triage,
+        fix: Fix | None,
+        escalation: EscalationSummary | None = None,
+    ) -> Alert:
         """Generate and send a Slack notification.
 
+        Exactly one of *fix* or *escalation* must be provided.  If *fix* is
+        supplied the normal fix-ready message is sent.  If *escalation* is
+        supplied (and *fix* is None) the agent was unable to produce a fix and
+        an escalation alert is sent instead.
+
         Args:
-            failure: Original CI failure.
-            triage:  Triage results from TriageAgent.
-            fix:     Fix details from FixAgent.
+            failure:    Original CI failure.
+            triage:     Triage results from TriageAgent.
+            fix:        Fix details from FixAgent, or None when escalating.
+            escalation: Escalation summary when fix_confidence is LOW, or None.
+
+        Raises:
+            ValueError: If both *fix* and *escalation* are None.
 
         Returns:
             Alert model with the message that was sent.
         """
+        if fix is None and escalation is None:
+            raise ValueError("NotifyAgent.run requires either fix or escalation — both are None.")
+
         self._status = AgentStatus.RUNNING
         logger.info("NotifyAgent: preparing alert for %s", failure.id)
 
         try:
-            slack_message = self._generate_message(failure, triage, fix)
+            if fix is not None:
+                slack_message = self._generate_message(failure, triage, fix)
+            else:
+                assert escalation is not None  # narrowing — already checked above
+                slack_message = self._generate_escalation_message(failure, triage, escalation)
 
             if self.demo_mode or (not self.slack_bot_token and not self.slack_webhook_url):
                 self._console_output(slack_message)
@@ -148,6 +171,37 @@ PR number: {fix.pr_number}
 
 Use this severity emoji: {emoji}
 Channel context: {self.channel}"""
+
+        return self._call_llm(
+            system=SYSTEM_PROMPT,
+            user=user_message,
+            max_tokens=300,
+        ).strip()
+
+    def _generate_escalation_message(
+        self,
+        failure: Failure,
+        triage: Triage,
+        escalation: EscalationSummary,
+    ) -> str:
+        """Generate a Slack message for a LOW-confidence escalation (no fix produced)."""
+        emoji = SEVERITY_EMOJI.get(triage.severity, ":white_circle:")
+        user_message = f"""Generate a Slack notification for a CI incident that could NOT be fixed automatically.
+
+Repository: {failure.pipeline.repo}
+Branch: {failure.pipeline.branch}
+Commit: {failure.pipeline.commit}
+Job: {failure.failure.job}
+
+What was investigated: {escalation.what_was_investigated}
+What was inconclusive: {escalation.what_was_inconclusive}
+Recommended next step: {escalation.recommended_next_step}
+Severity: {triage.severity.value.upper()}
+
+Use this severity emoji: {emoji}
+Channel context: {self.channel}
+
+Make clear that human review is required — the agent was unable to produce a fix with sufficient confidence."""
 
         return self._call_llm(
             system=SYSTEM_PROMPT,

--- a/agents/tools/fix_tools.py
+++ b/agents/tools/fix_tools.py
@@ -7,9 +7,9 @@ Phase 3 workers can discover and use them.
 
 Permission levels:
   - GetRepoTreeTool : READ_ONLY  — safe listing, no side effects
-  - CreateBranchTool: WRITE      — creates a git branch
-  - UpdateFileTool  : WRITE      — commits a file change to a branch
-  - OpenDraftPRTool : WRITE      — opens a draft PR/MR
+  - CreateBranchTool: WRITE                — creates a git branch
+  - UpdateFileTool  : REQUIRES_CONFIRMATION — commits a file change to a branch
+  - OpenDraftPRTool : REQUIRES_CONFIRMATION — opens a draft PR/MR
 
 All tools are stateless. Runtime dependencies arrive via ToolContext.
 """
@@ -213,7 +213,7 @@ class UpdateFileTool(Tool):
 
     @property
     def permission(self) -> Permission:
-        return Permission.WRITE
+        return Permission.REQUIRES_CONFIRMATION
 
     async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
         if ctx.provider is None:
@@ -293,7 +293,7 @@ class OpenDraftPRTool(Tool):
 
     @property
     def permission(self) -> Permission:
-        return Permission.WRITE
+        return Permission.REQUIRES_CONFIRMATION
 
     async def execute(self, input: dict, ctx: ToolContext) -> ToolResult:
         if ctx.provider is None:

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -33,6 +33,7 @@ from shared.agent_loop import AgentLoop, LoopOutcome, LoopResult, Permission, To
 from shared.models import AgentStatus, Failure, Severity, Triage
 from shared.tenant_context import TenantContext
 from shared.tool_registry import ToolRegistry
+from shared.trust_context import TrustContext
 
 if TYPE_CHECKING:
     from providers.base import CIProvider
@@ -93,12 +94,14 @@ class TriageAgent(BaseAgent[Triage]):
         registry: ToolRegistry | None = None,
         context_budget: ContextBudget | None = None,
         tenant_context: TenantContext | None = None,
+        trust_context: TrustContext | None = None,
     ) -> None:
         super().__init__(backend=backend, model=model)
         self._provider = provider
         self._max_turns = max_turns
         self._context_budget = context_budget
         self._tenant_context = tenant_context
+        self._trust_context = trust_context
         if registry is None:
             registry = ToolRegistry()
             registry.register(GetFileTool())
@@ -159,6 +162,8 @@ class TriageAgent(BaseAgent[Triage]):
             max_turns=self._max_turns,
             context_budget=self._context_budget,
             tenant_context=self._tenant_context,
+            trust_context=self._trust_context,
+            actor="TriageAgent",
         )
         ctx = ToolContext(
             provider=self._provider,

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,9 +16,11 @@
       --yellow: #d29922;
       --red: #f85149;
       --purple: #bc8cff;
+      --amber: #f0883e;
       --panel-inactive: #161b22;
       --panel-active: #1c2128;
       --panel-done: #0d1f0d;
+      --panel-escalated: #1f1a0d;
       --font-mono: 'SF Mono', 'Fira Code', 'Consolas', monospace;
     }
 
@@ -82,6 +84,7 @@
     }
     .scenario-btn:hover { border-color: var(--accent); background: #1c2128; }
     .scenario-btn.active { border-color: var(--accent); background: #1a2535; color: var(--accent); }
+    .scenario-btn.active-escalation { border-color: var(--amber); background: #1f1a0d; color: var(--amber); }
     .scenario-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
     #pipeline-info {
@@ -123,6 +126,7 @@
     }
     .panel.running { border-color: var(--accent); background: var(--panel-active); box-shadow: 0 0 0 1px rgba(88,166,255,0.15); }
     .panel.done { border-color: var(--green); background: var(--panel-done); }
+    .panel.escalated { border-color: var(--amber); background: var(--panel-escalated); }
 
     .panel-header { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
     .panel-icon { font-size: 16px; }
@@ -138,6 +142,7 @@
     }
     .panel.running .status-dot { background: var(--accent); animation: pulse 1s infinite; }
     .panel.done .status-dot { background: var(--green); animation: none; }
+    .panel.escalated .status-dot { background: var(--amber); animation: none; }
 
     @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
 
@@ -147,9 +152,27 @@
       line-height: 1.5;
       min-height: 60px;
       word-break: break-word;
+      max-height: 220px;
+      overflow-y: auto;
     }
     .panel.running .panel-output,
-    .panel.done .panel-output { color: var(--text); }
+    .panel.done .panel-output,
+    .panel.escalated .panel-output { color: var(--text); }
+
+    /* Tool call animation lines */
+    .tool-call-line {
+      color: var(--accent);
+      font-size: 11px;
+      margin-top: 5px;
+      opacity: 0.9;
+    }
+    .tool-result-line {
+      color: var(--muted);
+      font-size: 11px;
+      margin-bottom: 3px;
+      padding-left: 10px;
+      border-left: 2px solid var(--border);
+    }
 
     .cursor {
       display: inline-block;
@@ -191,6 +214,7 @@
       padding: 20px;
     }
     .result-card h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); margin-bottom: 12px; }
+    .result-card.escalation-card { border-color: var(--amber); }
 
     .pr-title { font-size: 14px; color: var(--accent); margin-bottom: 8px; }
     .pr-link {
@@ -215,6 +239,35 @@
       margin-top: 8px;
       border-top: 1px solid var(--border);
       padding-top: 10px;
+    }
+
+    /* Escalation result card */
+    .escalation-badge {
+      color: var(--amber);
+      font-size: 12px;
+      font-weight: 700;
+      margin-bottom: 14px;
+    }
+    .escalation-field {
+      font-size: 12px;
+      color: var(--muted);
+      line-height: 1.6;
+      margin-bottom: 10px;
+    }
+    .escalation-field .field-label {
+      display: block;
+      color: var(--text);
+      font-weight: 700;
+      margin-bottom: 2px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .escalation-next {
+      border-top: 1px solid var(--border);
+      padding-top: 10px;
+      margin-top: 4px;
+      color: var(--amber);
     }
 
     .slack-msg {
@@ -249,6 +302,7 @@
     }
     .how-it-works p { color: var(--muted); font-size: 13px; line-height: 1.8; margin-bottom: 12px; }
     .how-it-works code { color: var(--accent); font-size: 12px; }
+    .how-it-works strong { color: var(--text); }
 
     footer {
       text-align: center;
@@ -308,8 +362,8 @@
 
     <div class="panel" id="panel-fix">
       <div class="panel-header">
-        <span class="panel-icon">🔧</span>
-        <span class="panel-name">Fix</span>
+        <span class="panel-icon" id="fix-panel-icon">🔧</span>
+        <span class="panel-name" id="fix-panel-name">Fix</span>
         <span class="status-dot"></span>
       </div>
       <div class="panel-output" id="out-fix">Idle</div>
@@ -328,8 +382,8 @@
   <div id="results">
     <h2>Results</h2>
     <div class="results-grid">
-      <div class="result-card">
-        <h3>Draft Pull Request</h3>
+      <div class="result-card" id="left-result-card">
+        <h3 id="left-result-title">Draft Pull Request</h3>
         <div id="pr-content">—</div>
       </div>
       <div class="result-card">
@@ -343,11 +397,18 @@
 
   <div class="how-it-works">
     <h2>How it works</h2>
-    <p>ops-pilot runs four agents in sequence: <code>Monitor → Triage → Fix → Notify</code>.</p>
-    <p><code>MonitorAgent</code> polls GitHub Actions for failed runs and builds a typed <code>Failure</code> model from the log tail.</p>
-    <p><code>TriageAgent</code> sends the logs to Claude and extracts root cause, severity, and fix confidence into a structured <code>Triage</code> model.</p>
-    <p><code>FixAgent</code> asks Claude which file to edit, fetches it from GitHub, generates a minimal patch, and opens a draft PR — humans review before anything merges.</p>
-    <p><code>NotifyAgent</code> writes a concise Slack message via Claude and posts it to the configured channel.</p>
+    <p>ops-pilot runs an agentic pipeline: <code>Monitor → Triage → Fix (or Escalate) → Notify</code>.</p>
+
+    <p><code>MonitorAgent</code> polls GitHub Actions, GitLab CI, or Jenkins every 30 seconds. When a failure lands it builds a typed <code>Failure</code> model — log tail, diff summary, pipeline metadata — and hands off to triage.</p>
+
+    <p><code>TriageAgent</code> runs a <strong>tool-use loop</strong> instead of a single prompt. The model calls <code>get_file</code> to read source at the failing line, <code>get_more_log</code> to fetch earlier log sections (the root cause is often 50–100 lines above the tail), and <code>get_commit_diff</code> to read the actual diff hunks — until it decides it has enough evidence to conclude. You can see those tool calls above as each scenario runs. For complex incidents a <strong>CoordinatorAgent</strong> spawns parallel workers (log / source / diff) and aggregates their findings.</p>
+
+    <p>If triage confidence is <strong>HIGH or MEDIUM</strong>, <code>FixAgent</code> generates a minimal patch, commits it to a branch, and opens a <strong>draft PR</strong> — nothing merges without a human. If confidence is <strong>LOW</strong>, ops-pilot generates an <strong>escalation summary</strong> instead: what was investigated, what was inconclusive, and the recommended next step. Try the ⚠️ OOM scenario above to see this path.</p>
+
+    <p><code>NotifyAgent</code> posts either a fix-ready alert with the PR link, or a human-review-required escalation alert to Slack. Every tool call is written to a structured <strong>JSONL audit trail</strong>. Destructive actions — file commits and PR opens — get a pre-action LLM explanation logged before execution.</p>
+
+    <p>Additional capabilities: <strong>incident memory</strong> with weighted similarity retrieval surfaces past fixes before triage begins; <strong>context budgeting</strong> compacts tool results when the context window fills; <strong>per-tenant isolation</strong> with rate limiting for enterprise deployments. A weekly consolidation job distills raw incident logs into durable fix patterns.</p>
+
     <p>This demo replays pre-recorded runs — click any scenario above to see the full pipeline in action.</p>
   </div>
 </main>
@@ -358,18 +419,21 @@
 </footer>
 
 <script>
-  // Scenario definitions — fetched from static JSON files (no server needed)
   const SCENARIOS = [
     { id: 'null_pointer_auth',         label: '🔴 Null pointer crash — auth service' },
     { id: 'missing_dependency_docker', label: '📦 Missing dependency — Docker build' },
     { id: 'flaky_integration_test',    label: '🔁 Flaky integration test — payments' },
+    { id: 'oom_kill_recommender',      label: '⚠️ OOM kill — recommender (escalation)' },
   ];
 
   const TYPEWRITER_SPEED = 18; // ms per character
-  const AGENT_PAUSE     = 600; // ms between agents
+  const AGENT_PAUSE      = 600; // ms between agents
+  const TOOL_CALL_PAUSE  = 550; // ms after showing call line
+  const TOOL_RESULT_PAUSE = 380; // ms after showing result line
 
-  let running = false;
-  let aborted = false;
+  let running  = false;
+  let aborted  = false;
+  let isEscalationScenario = false;
 
   // ── Bootstrap ───────────────────────────────────────────────────────────────
   function init() {
@@ -389,8 +453,9 @@
     if (running) return;
     running = true;
     aborted = false;
+    isEscalationScenario = false;
 
-    document.querySelectorAll('.scenario-btn').forEach(b => { b.classList.remove('active'); b.disabled = true; });
+    document.querySelectorAll('.scenario-btn').forEach(b => { b.classList.remove('active', 'active-escalation'); b.disabled = true; });
     btn.classList.add('active');
     resetPanels();
     document.getElementById('results').classList.remove('visible');
@@ -405,6 +470,13 @@
       console.error('Failed to load scenario', e);
       running = false;
       return;
+    }
+
+    // Detect escalation scenario
+    isEscalationScenario = scenario.agents.some(s => s.agent === 'escalate');
+    if (isEscalationScenario) {
+      btn.classList.remove('active');
+      btn.classList.add('active-escalation');
     }
 
     showPipelineInfo(scenario.pipeline);
@@ -424,17 +496,61 @@
 
   // ── Animate one agent step ──────────────────────────────────────────────────
   async function runAgentStep(step) {
-    const agent = step.agent;
-    setPanel(agent, 'running');
-    setOutput(agent, '');
+    // Map escalate step onto the fix panel
+    const panelAgent = step.agent === 'escalate' ? 'fix' : step.agent;
 
-    await typewrite(agent, step.output);
+    // Update Fix panel label for escalation
+    if (step.agent === 'escalate') {
+      document.getElementById('fix-panel-icon').textContent = '⚠️';
+      document.getElementById('fix-panel-name').textContent = 'Escalate';
+    }
 
-    setPanel(agent, 'done');
+    setPanel(panelAgent, 'running');
+    setOutput(panelAgent, '');
 
-    if (step.severity) showSeverityBadge(step.severity);
+    // Show tool-use loop for triage (and any other step that has tool_calls)
+    if (step.tool_calls && step.tool_calls.length > 0) {
+      await showToolCallSteps(panelAgent, step.tool_calls);
+      if (!aborted) setOutput(panelAgent, ''); // clear tool calls, then show conclusion
+    }
+
+    await typewrite(panelAgent, step.output);
+
+    // Done state — escalation uses amber, normal uses green
+    const doneClass = step.agent === 'escalate' ? 'escalated' : 'done';
+    setPanel(panelAgent, doneClass);
+
+    if (step.severity)      showSeverityBadge(step.severity);
     if (step.pr_title)      showPrResult(step);
+    if (step.agent === 'escalate') showEscalationResult(step);
     if (step.slack_message) showSlackResult(step.slack_message);
+  }
+
+  // ── Animate tool call steps inside a panel ──────────────────────────────────
+  async function showToolCallSteps(agent, toolCalls) {
+    const el = document.getElementById(`out-${agent}`);
+
+    for (const tc of toolCalls) {
+      if (aborted) break;
+
+      const callLine = document.createElement('div');
+      callLine.className = 'tool-call-line';
+      callLine.textContent = `⟩ ${tc.tool}(${tc.input || ''})`;
+      el.appendChild(callLine);
+
+      await sleep(TOOL_CALL_PAUSE);
+      if (aborted) break;
+
+      const resultLine = document.createElement('div');
+      resultLine.className = 'tool-result-line';
+      resultLine.textContent = `↳ ${tc.summary}`;
+      el.appendChild(resultLine);
+
+      // Scroll to bottom as lines accumulate
+      el.scrollTop = el.scrollHeight;
+
+      await sleep(TOOL_RESULT_PAUSE);
+    }
   }
 
   // ── Typewriter effect ───────────────────────────────────────────────────────
@@ -443,7 +559,6 @@
       const el = document.getElementById(`out-${agent}`);
       let i = 0;
 
-      // Add blinking cursor
       const cursor = document.createElement('span');
       cursor.className = 'cursor';
       el.appendChild(cursor);
@@ -455,7 +570,6 @@
           resolve();
           return;
         }
-        // Batch a few chars per frame for speed
         const chunk = text.slice(i, i + 3);
         cursor.insertAdjacentText('beforebegin', chunk);
         i += chunk.length;
@@ -473,6 +587,13 @@
       document.getElementById(`panel-${agent}`).className = 'panel';
       document.getElementById(`out-${agent}`).textContent = agent === 'monitor' ? 'Waiting for CI failure…' : 'Idle';
     });
+    // Reset Fix panel icon/label (may have been changed to Escalate)
+    document.getElementById('fix-panel-icon').textContent = '🔧';
+    document.getElementById('fix-panel-name').textContent = 'Fix';
+    // Reset left result card
+    document.getElementById('left-result-card').classList.remove('escalation-card');
+    document.getElementById('left-result-title').textContent = 'Draft Pull Request';
+
     document.getElementById('severity-badge').innerHTML = '';
     document.getElementById('pipeline-info').innerHTML = '';
     document.getElementById('pr-content').innerHTML = '—';
@@ -497,6 +618,27 @@
       <div class="pr-title">${esc(step.pr_title)}</div>
       <a class="pr-link" href="${esc(step.pr_url || '#')}" target="_blank">View PR #${esc(String(step.pr_number || '?'))} →</a>
       <div class="pr-body">${esc(step.pr_body || '')}</div>
+    `;
+  }
+
+  function showEscalationResult(step) {
+    const card = document.getElementById('left-result-card');
+    card.classList.add('escalation-card');
+    document.getElementById('left-result-title').textContent = 'Escalation Summary';
+    document.getElementById('pr-content').innerHTML = `
+      <div class="escalation-badge">⚠️ Human review required — no PR opened</div>
+      <div class="escalation-field">
+        <span class="field-label">Investigated</span>
+        ${esc(step.what_was_investigated || '')}
+      </div>
+      <div class="escalation-field">
+        <span class="field-label">Inconclusive</span>
+        ${esc(step.what_was_inconclusive || '')}
+      </div>
+      <div class="escalation-field escalation-next">
+        <span class="field-label">Recommended next step</span>
+        ${esc(step.recommended_next_step || '')}
+      </div>
     `;
   }
 
@@ -527,7 +669,7 @@
     resetPanels();
     document.getElementById('results').classList.remove('visible');
     document.getElementById('reset-btn').style.display = 'none';
-    document.querySelectorAll('.scenario-btn').forEach(b => { b.classList.remove('active'); b.disabled = false; });
+    document.querySelectorAll('.scenario-btn').forEach(b => { b.classList.remove('active', 'active-escalation'); b.disabled = false; });
   });
 
   init();

--- a/docs/scenarios/flaky_integration_test.json
+++ b/docs/scenarios/flaky_integration_test.json
@@ -46,7 +46,7 @@
     "files_changed": ["payments/processor.py", "payments/webhook_handler.py", "tests/integration/test_payment_flow.py"],
     "lines_added": 201,
     "lines_removed": 87,
-    "key_change": "PaymentProcessor extracted into standalone class. Webhook handler now persists idempotency keys to Postgres instead of in-memory dict. Test does not reset Postgres state between the two webhook calls — idempotency key from call 1 is still present when call 2 runs, causing 409 instead of 200."
+    "key_change": "PaymentProcessor extracted into standalone class. Webhook handler now persists idempotency keys to Postgres instead of in-memory dict. Test does not reset Postgres state between the two webhook calls."
   },
   "agents": [
     {
@@ -59,7 +59,29 @@
       "agent": "triage",
       "status": "complete",
       "timestamp": "2026-03-30T03:52:31Z",
-      "output": "Root cause identified — this is a test environment issue, NOT a production bug. Commit f7b93a1 moved idempotency key storage from an in-memory dict (reset automatically between requests in tests) to Postgres (persists across requests within the same test run). The test calls the webhook endpoint twice with the same payload without resetting Postgres state between calls. The 409 on the second call is correct production behavior — the test setup is wrong. Fix: add a teardown fixture that deletes idempotency keys from Postgres between test calls, or generate a unique idempotency key per test run. Production code is correct. Fix confidence: HIGH. Flakiness explained: test passes when the two POST calls happen across separate test sessions (key not present), fails when they share a session (key present from call 1).",
+      "tool_calls": [
+        {
+          "tool": "get_more_log",
+          "input": "offset=0, lines=100",
+          "summary": "Earlier logs show test passed on 7 of last 10 runs — failure is timing-dependent, not consistent"
+        },
+        {
+          "tool": "get_file",
+          "input": "payments/webhook_handler.py",
+          "summary": "Read webhook handler — idempotency keys now persisted to Postgres (was in-memory dict); keys survive across requests within the same test session"
+        },
+        {
+          "tool": "get_file",
+          "input": "tests/integration/test_payment_flow.py:100-120",
+          "summary": "Read test — no teardown fixture clears the idempotency_keys table between the two POST calls; key from call 1 is present when call 2 runs"
+        },
+        {
+          "tool": "get_commit_diff",
+          "input": "f7b93a1",
+          "summary": "Diff confirms storage migration: in-memory dict → Postgres. Production behavior (409 on duplicate) is correct — test setup is the regression"
+        }
+      ],
+      "output": "Root cause: this is a test environment issue, NOT a production bug. Commit f7b93a1 moved idempotency key storage from in-memory dict (reset automatically between requests) to Postgres (persists within the same test session). The test sends the same webhook twice without resetting the table — the 409 on the second call is correct production behavior. Flakiness explained: passes when two POSTs run across separate test sessions (key absent), fails when they share a session (key present from call 1). Fix: add teardown fixture to delete idempotency keys between calls. Fix confidence: HIGH.",
       "severity": "low",
       "affected_service": "payments",
       "regression_introduced_in": "f7b93a1",
@@ -71,7 +93,7 @@
       "timestamp": "2026-03-30T03:52:47Z",
       "output": "Fix generated and draft PR opened.",
       "pr_title": "fix(tests): reset Postgres idempotency keys between webhook calls in integration test",
-      "pr_body": "## Problem\n`test_stripe_webhook_idempotency` is flaky after `f7b93a1` moved idempotency key storage from in-memory to Postgres.\n\nThe test sends the same webhook payload twice to verify idempotency. With in-memory storage this worked fine — the dict was scoped per request. With Postgres, the key from call 1 persists when call 2 runs, so call 2 correctly returns 409 (idempotent rejection) rather than 200.\n\n**Production code is correct.** The test fixture needs updating.\n\n## Fix\nAdd a `@pytest.fixture` that cleans up the `idempotency_keys` table between calls:\n\n```python\n@pytest.fixture(autouse=True)\ndef clean_idempotency_keys(db_session):\n    yield\n    db_session.execute(text(\"DELETE FROM idempotency_keys WHERE created_at > NOW() - INTERVAL '5 minutes'\"))\n    db_session.commit()\n```\n\nAlternatively, generate a unique `idempotency_key` per test invocation so retries never collide.\n\n## Note\nThis is a test infrastructure fix only. No production code changes. The 409 behavior is correct and desirable.\n\n---\n*This PR was opened automatically by ops-pilot.*",
+      "pr_body": "## Problem\n`test_stripe_webhook_idempotency` is flaky after `f7b93a1` moved idempotency key storage from in-memory to Postgres.\n\nThe test sends the same webhook payload twice to verify idempotency. With in-memory storage this worked fine — the dict was scoped per request. With Postgres, the key from call 1 persists when call 2 runs, so call 2 correctly returns 409 rather than 200.\n\n**Production code is correct.** The test fixture needs updating.\n\n## Fix\nAdd a `@pytest.fixture` that cleans up the `idempotency_keys` table between calls:\n\n```python\n@pytest.fixture(autouse=True)\ndef clean_idempotency_keys(db_session):\n    yield\n    db_session.execute(text(\"DELETE FROM idempotency_keys WHERE created_at > NOW() - INTERVAL '5 minutes'\"))\n    db_session.commit()\n```\n\n## Note\nThis is a test infrastructure fix only. No production code changes.\n\n---\n*This PR was opened automatically by ops-pilot. Audit log entry written for all tool calls.*",
       "pr_url": "https://github.com/acme-corp/payments/pull/589",
       "pr_number": 589
     },

--- a/docs/scenarios/missing_dependency_docker.json
+++ b/docs/scenarios/missing_dependency_docker.json
@@ -31,7 +31,6 @@
       "Dockerfile:18",
       "--------------------",
       "  17 |   COPY requirements.txt .",
-
       "  18 | >>> RUN pip install -r requirements.txt",
       "  19 |   COPY . .",
       "--------------------",
@@ -55,7 +54,24 @@
       "agent": "triage",
       "status": "complete",
       "timestamp": "2026-03-29T09:18:43Z",
-      "output": "Root cause identified: polars==0.20.15 requires pyarrow>=14.0.0 but the Dockerfile base image python:3.9-slim ships pyarrow 13.0.0. Two valid fixes: (1) pin pyarrow==14.0.1 explicitly in requirements.txt before polars — pip will upgrade it, or (2) downgrade to polars==0.19.19 which is compatible with pyarrow 13.x. Option 1 is preferred — keeps the newer polars version the author intended. Fix confidence: HIGH.",
+      "tool_calls": [
+        {
+          "tool": "get_file",
+          "input": "requirements.txt",
+          "summary": "Read requirements.txt — polars==0.20.15 added in this commit; PyPI metadata confirms it requires pyarrow>=14.0.0"
+        },
+        {
+          "tool": "get_file",
+          "input": "Dockerfile",
+          "summary": "Read Dockerfile — base image is python:3.9-slim, which ships pyarrow==13.0.0; no base image bump in this commit"
+        },
+        {
+          "tool": "get_commit_diff",
+          "input": "d9c04e2",
+          "summary": "Diff confirms: only requirements.txt changed (polars added, pandas bumped); Dockerfile untouched"
+        }
+      ],
+      "output": "Root cause: polars==0.20.15 requires pyarrow>=14.0.0 but the Dockerfile base image python:3.9-slim ships pyarrow 13.0.0. Transitive dependency conflict introduced by this commit. Two valid fixes: (1) pin pyarrow==14.0.1 explicitly before polars in requirements.txt — preferred, keeps the newer polars; (2) downgrade to polars==0.19.19 which is compatible with pyarrow 13.x. Fix confidence: HIGH.",
       "severity": "medium",
       "affected_service": "data-pipeline",
       "regression_introduced_in": "d9c04e2"
@@ -66,7 +82,7 @@
       "timestamp": "2026-03-29T09:18:58Z",
       "output": "Fix generated and draft PR opened.",
       "pr_title": "fix(deps): pin pyarrow>=14.0.1 to satisfy polars==0.20.15 requirement",
-      "pr_body": "## Problem\n`polars==0.20.15` requires `pyarrow>=14.0.0` but the Docker base image `python:3.9-slim` ships `pyarrow==13.0.0`. The build fails at the `pip install` step.\n\n## Fix\nAdd explicit `pyarrow==14.0.1` pin to `requirements.txt` *before* the polars line so pip resolves the upgrade correctly.\n\n```diff\n # requirements.txt\n pandas==2.2.1\n+pyarrow==14.0.1\n polars==0.20.15\n```\n\n## Why not downgrade polars?\nThe original commit message indicates polars was added intentionally for performance. Keeping 0.20.15 and resolving the transitive dependency is the right call.\n\n## Verification\nLocal build with this change: `docker build --no-cache .` completes successfully.\n\n---\n*This PR was opened automatically by ops-pilot.*",
+      "pr_body": "## Problem\n`polars==0.20.15` requires `pyarrow>=14.0.0` but the Docker base image `python:3.9-slim` ships `pyarrow==13.0.0`. The build fails at the `pip install` step.\n\n## Fix\nAdd explicit `pyarrow==14.0.1` pin to `requirements.txt` *before* the polars line so pip resolves the upgrade correctly.\n\n```diff\n # requirements.txt\n pandas==2.2.1\n+pyarrow==14.0.1\n polars==0.20.15\n```\n\n## Why not downgrade polars?\nThe original commit message indicates polars was added intentionally for performance. Keeping 0.20.15 and resolving the transitive dependency is the right call.\n\n---\n*This PR was opened automatically by ops-pilot. Audit log entry written for all tool calls.*",
       "pr_url": "https://github.com/acme-corp/data-pipeline/pull/312",
       "pr_number": 312
     },

--- a/docs/scenarios/null_pointer_auth.json
+++ b/docs/scenarios/null_pointer_auth.json
@@ -57,7 +57,24 @@
       "agent": "triage",
       "status": "complete",
       "timestamp": "2026-03-28T14:26:52Z",
-      "output": "Root cause identified: commit a3f21b7 removed a null-guard in SessionManager.__init__ (auth/session_manager.py:87). Redis returns None for uncached sessions in the test environment — previously this raised a ValueError (caught by callers), now None propagates to rotate_token() causing AttributeError. This is a regression introduced by the OAuth refresh token feature. Fix confidence: HIGH.",
+      "tool_calls": [
+        {
+          "tool": "get_more_log",
+          "input": "offset=0, lines=80",
+          "summary": "80 earlier lines fetched — Redis returning None for session:usr_abc123 appears 12 lines above the AttributeError tail"
+        },
+        {
+          "tool": "get_file",
+          "input": "auth/session_manager.py",
+          "summary": "Read lines 80-95 — null-guard (raise ValueError on None) was present before this commit, removed in a3f21b7 with no replacement"
+        },
+        {
+          "tool": "get_commit_diff",
+          "input": "a3f21b7",
+          "summary": "Full diff confirms: only the null-guard removal is relevant; no other changes affect the hydration path"
+        }
+      ],
+      "output": "Root cause: commit a3f21b7 removed a null-guard in SessionManager.__init__ (auth/session_manager.py:87). Redis returns None for uncached sessions in the test environment — previously this raised ValueError (caught by callers), now None propagates to rotate_token() causing AttributeError. Regression introduced by this commit. Fix confidence: HIGH.",
       "severity": "high",
       "affected_service": "auth-service",
       "regression_introduced_in": "a3f21b7"
@@ -68,7 +85,7 @@
       "timestamp": "2026-03-28T14:27:08Z",
       "output": "Fix generated and draft PR opened.",
       "pr_title": "fix(auth): restore null-guard in SessionManager Redis hydration",
-      "pr_body": "## Problem\nCommit `a3f21b7` removed a null-guard in `SessionManager.__init__` that previously raised `ValueError` when Redis returned `None` for an uncached session. This causes `AttributeError` in all callers that invoke methods on the resulting `None` object.\n\n## Root cause\n`auth/session_manager.py` line 87 — removed guard:\n```python\n# Before (safe)\nif raw is None:\n    raise ValueError(f'Session not found for user {user_id}')\n\n# After a3f21b7 (broken)\n# guard removed — None propagates silently\n```\n\n## Fix\nRestore the null-guard. Callers are already handling `ValueError` correctly.\n\n## Tests\n`test_refresh_token_rotation` and `test_expired_session_cleanup` will pass after this fix.\n\n---\n*This PR was opened automatically by ops-pilot.*",
+      "pr_body": "## Problem\nCommit `a3f21b7` removed a null-guard in `SessionManager.__init__` that previously raised `ValueError` when Redis returned `None` for an uncached session. This causes `AttributeError` in all callers that invoke methods on the resulting `None` object.\n\n## Root cause\n`auth/session_manager.py` line 87 — removed guard:\n```python\n# Before (safe)\nif raw is None:\n    raise ValueError(f'Session not found for user {user_id}')\n\n# After a3f21b7 (broken)\n# guard removed — None propagates silently\n```\n\n## Fix\nRestore the null-guard. Callers are already handling `ValueError` correctly.\n\n## Tests\n`test_refresh_token_rotation` and `test_expired_session_cleanup` will pass after this fix.\n\n---\n*This PR was opened automatically by ops-pilot. Every tool call is logged to the audit trail.*",
       "pr_url": "https://github.com/acme-corp/platform/pull/1847",
       "pr_number": 1847
     },

--- a/docs/scenarios/oom_kill_recommender.json
+++ b/docs/scenarios/oom_kill_recommender.json
@@ -1,0 +1,100 @@
+{
+  "id": "oom_kill_recommender",
+  "label": "⚠️ OOM kill — recommender (escalation)",
+  "pipeline": {
+    "provider": "github_actions",
+    "repo": "acme-corp/recommender",
+    "workflow": "load-test.yml",
+    "run_id": "8857334012",
+    "branch": "main",
+    "commit": "c2e8f91",
+    "commit_message": "perf: add LRU cache for user embeddings, increase batch size 256→1024",
+    "author": "ml-eng@acme-corp.com",
+    "triggered_at": "2026-03-31T22:10:05Z",
+    "failed_at": "2026-03-31T22:14:22Z",
+    "duration_seconds": 257
+  },
+  "failure": {
+    "job": "load-test",
+    "step": "Run recommendation load test",
+    "exit_code": 137,
+    "log_tail": [
+      "Running load test: 500 concurrent users, 60s duration",
+      "RSS at t=0s:   1.2 GB",
+      "RSS at t=30s:  2.1 GB  (cache warming up)",
+      "RSS at t=60s:  2.9 GB",
+      "RSS at t=90s:  3.6 GB",
+      "RSS at t=120s: 4.1 GB",
+      "Killed",
+      "",
+      "Process killed by OOM killer (exit code 137)",
+      "Container memory limit: 4096 MB",
+      "Peak RSS observed before kill: 4.1 GB",
+      "",
+      "k6 summary: 12847 requests completed before OOM",
+      "p50=42ms p95=318ms p99=891ms error_rate=0.02%"
+    ]
+  },
+  "diff_summary": {
+    "files_changed": ["recommender/embedding_cache.py", "recommender/batch_processor.py", "recommender/config.py"],
+    "lines_added": 147,
+    "lines_removed": 23,
+    "key_change": "Two changes in same commit: (1) LRU embedding cache added with maxsize=50000; (2) batch_size increased from 256 to 1024 for throughput improvement"
+  },
+  "agents": [
+    {
+      "agent": "monitor",
+      "status": "triggered",
+      "timestamp": "2026-03-31T22:14:25Z",
+      "output": "CI failure detected on acme-corp/recommender — branch main, commit c2e8f91. Job: load-test. Process killed with exit code 137 (OOM). Memory grew from 1.2GB to 4.1GB in 2 minutes. Handing off to triage."
+    },
+    {
+      "agent": "triage",
+      "status": "complete",
+      "timestamp": "2026-03-31T22:14:41Z",
+      "tool_calls": [
+        {
+          "tool": "get_more_log",
+          "input": "offset=0, lines=200",
+          "summary": "Full load test log: memory growth is steady and linear — 3.2GB increase over ~120 seconds, no spikes; looks like a capacity ceiling, not a leak"
+        },
+        {
+          "tool": "get_file",
+          "input": "recommender/embedding_cache.py",
+          "summary": "Read cache implementation — LRU with maxsize=50000; each entry stores a user_id + 1536-dim float32 embedding ≈ 6.1KB; at capacity: ~300MB. Alone this is within limits."
+        },
+        {
+          "tool": "get_file",
+          "input": "recommender/batch_processor.py",
+          "summary": "Read batch processor — batch_size 256→1024 means 4× more embeddings held in-flight simultaneously; at peak: 1024 × 6.1KB ≈ 6MB per batch. Alone this is negligible."
+        },
+        {
+          "tool": "get_commit_diff",
+          "input": "c2e8f91",
+          "summary": "Both changes are in this single commit — cannot test them in isolation from CI history. Cache warm-up curve + batch concurrency interaction is non-deterministic without a profiler."
+        }
+      ],
+      "output": "Memory grew 3.2GB in 120s leading to OOM kill at the 4GB container limit. Two changes in c2e8f91 each contribute: (1) LRU cache with maxsize=50000 — at capacity ~300MB, acceptable alone; (2) batch_size 256→1024 — 4× more embeddings in-flight, ~6MB per batch, also acceptable alone. Cannot determine root cause without profiling: the interaction between cache warm-up concurrency and in-flight batch memory is non-deterministic, and both changes land in the same commit with no baseline for comparison. A rollback would fix the OOM but lose the intended perf gain — not the right call without knowing which change is responsible. Fix confidence: LOW.",
+      "severity": "high",
+      "affected_service": "recommender",
+      "regression_introduced_in": "c2e8f91"
+    },
+    {
+      "agent": "escalate",
+      "status": "complete",
+      "timestamp": "2026-03-31T22:14:48Z",
+      "output": "Escalation summary generated — human review required. ops-pilot cannot propose a safe fix without memory profiling data.",
+      "what_was_investigated": "OOM kill logs (4GB limit hit in ~120s), LRU cache implementation (maxsize=50000, ~300MB at capacity), batch processor (batch_size 256→1024, ~6MB per batch), and full commit diff for c2e8f91. Memory growth is linear — consistent with a capacity ceiling, not a classic leak.",
+      "what_was_inconclusive": "Cannot isolate which change caused OOM: both are in the same commit with no CI baseline between them. Cache warm-up concurrency + batch concurrency interact in a way that is non-deterministic without a memory profiler. Neither change causes OOM in isolation based on static analysis.",
+      "recommended_next_step": "Run memray or py-spy against the load test with each change applied separately. Start with batch_size=256 and the new cache enabled — if OOM disappears, the batch size is the culprit and lowering maxsize or batch_size is the fix. If OOM persists, the cache ceiling needs reducing.",
+      "slack_message": ":rotating_light: *OOM kill — recommender service* | branch `main` | commit `c2e8f91`\n\n*Investigated:* LRU cache (50k entries, ~300MB at capacity) + batch_size 256→1024. Memory grew 3.2GB in 2 min. Static analysis cannot isolate root cause — both changes land in the same commit.\n\n*⚠️ Human review required* — ops-pilot cannot propose a safe fix without memory profiling data.\n\n*Recommended:* Run memray with each change in isolation. Start by testing batch_size=256 with cache enabled.\n\n*Severity:* HIGH | _ops-pilot_"
+    },
+    {
+      "agent": "notify",
+      "status": "complete",
+      "timestamp": "2026-03-31T22:14:49Z",
+      "output": "Team notified via Slack #ml-eng-oncall.",
+      "slack_message": ":rotating_light: *OOM kill — recommender service* | branch `main` | commit `c2e8f91`\n\n*Investigated:* LRU cache (50k entries, ~300MB at capacity) + batch_size 256→1024. Memory grew 3.2GB in 2 min. Static analysis cannot isolate root cause — both changes land in the same commit.\n\n*⚠️ Human review required* — ops-pilot cannot propose a safe fix without memory profiling data.\n\n*Recommended:* Run memray with each change in isolation. Start by testing batch_size=256 with cache enabled.\n\n*Severity:* HIGH | _ops-pilot_"
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-04-06-phase7-trust-explainability-design.md
+++ b/docs/superpowers/specs/2026-04-06-phase7-trust-explainability-design.md
@@ -171,7 +171,8 @@ On backend failure: returns a minimal `EscalationSummary` with `what_was_investi
 | Location | Change |
 |---|---|
 | `AgentLoop.__init__` | Add `trust_context: TrustContext \| None = None` and `actor: str = "agent"` parameters |
-| `AgentLoop.run_one()` — before `REQUIRES_CONFIRMATION` execution | Call `trust_context.explanation_generator.generate(tool_name, tool_input, last_text)` |
+| `AgentLoop._execute_tools_concurrent()` | Add `last_text: str` parameter so the explanation generator can use the current investigation summary as context |
+| `AgentLoop.run_one()` — `REQUIRES_CONFIRMATION` gate | If `trust_context` is set: generate explanation and auto-proceed (Phase 7 — observability without blocking). If `trust_context` is absent: fall through to existing `confirm` hook gate (Phase 8 will wire real approval there) |
 | `AgentLoop.run_one()` — after any tool execution | Call `trust_context.audit_log.record(...)` with all fields; `explanation` is `None` for non-confirmation tools |
 | `UpdateFileTool.permission` | Change return value from `Permission.WRITE` to `Permission.REQUIRES_CONFIRMATION` |
 | `OpenDraftPRTool.permission` | Change return value from `Permission.WRITE` to `Permission.REQUIRES_CONFIRMATION` |
@@ -225,4 +226,4 @@ Both the `audit/` directory and its files are gitignored. The directory is creat
 
 ## Future Upgrade Path
 
-Phase 8 (human-in-the-loop approval): replace the auto-proceed behaviour after explanation generation with a real approval gate. The seam is already in place — `AgentLoop`'s `confirm` hook is wired but always returns `True` implicitly in Phase 7 (execution proceeds after explanation). Phase 8 wires a real async approval callback there. Zero changes to `AuditLog`, `ExplanationGenerator`, or any tool definitions.
+Phase 8 (human-in-the-loop approval): replace the auto-proceed behaviour in the `trust_context` branch with a real approval gate. The seam is already in place — when `trust_context` is set and a `confirm` hook is also provided, Phase 8 can check the hook result after explanation generation instead of auto-proceeding. Zero changes to `AuditLog`, `ExplanationGenerator`, or any tool definitions. The `confirm` hook signature is unchanged.

--- a/docs/superpowers/specs/2026-04-06-phase7-trust-explainability-design.md
+++ b/docs/superpowers/specs/2026-04-06-phase7-trust-explainability-design.md
@@ -1,0 +1,228 @@
+# Phase 7 — Trust & Explainability Layer Design
+
+**Date:** 2026-04-06
+**Branch:** feature/phase7-trust-explainability
+**Status:** Approved, pending implementation
+
+---
+
+## Context
+
+ops-pilot now runs autonomously through Phases 1–6: it triages failures, writes patches, opens PRs, tracks usage, and enforces rate limits — all without human involvement. Phase 7 makes this autonomy legible to the enterprise buyers who need to trust it. The deliverables are: explanations before risky actions, a structured audit trail of every tool call, LOW-confidence escalation instead of guessing, and confidence scoring surfaced in notifications.
+
+Deployment model: separate instance per customer (same code, isolated runtime data). No shared-process multi-tenancy.
+
+---
+
+## Goals
+
+1. **Pre-action explanations** — before executing `REQUIRES_CONFIRMATION` tools, generate a plain-English sentence explaining what the agent is about to do and why
+2. **Audit log** — every tool call recorded: tool name, arguments, result, timestamp, tenant, actor, explanation
+3. **Escalation path** — LOW confidence triage skips FixAgent entirely; a structured escalation summary is generated for the on-call engineer instead
+4. **Confidence in notifications** — `fix_confidence` surfaced prominently; escalation summary or fix summary included depending on outcome
+
+---
+
+## Architecture
+
+### New modules
+
+```
+shared/
+  audit_log.py          ← AuditLog — writes JSONL records to audit/YYYY-MM-DD.jsonl
+  explanation_gen.py    ← ExplanationGenerator — LLM call before REQUIRES_CONFIRMATION tools
+  escalation.py         ← generate_escalation_summary() — LLM call on LOW confidence
+  trust_context.py      ← TrustContext dataclass + make_trust_context() factory
+
+audit/                  ← runtime directory (gitignored)
+  YYYY-MM-DD.jsonl      ← one JSON record per line per audit event
+```
+
+### TrustContext
+
+```python
+@dataclass
+class TrustContext:
+    audit_log: AuditLog
+    explanation_generator: ExplanationGenerator
+```
+
+Constructed once at startup by `make_trust_context(config, backend) -> TrustContext`. Injected into `AgentLoop` alongside `TenantContext` — same injection pattern used throughout Phases 5 and 6. `ExplanationGenerator` receives the backend at construction time (same instance as `AgentLoop`) so test doubles are injectable and backend auth is not duplicated.
+
+```python
+def make_trust_context(config: OpsPilotConfig, backend) -> TrustContext:
+    return TrustContext(
+        audit_log=AuditLog(base_dir=Path("audit")),
+        explanation_generator=ExplanationGenerator(
+            backend=backend,
+            model=config.trust.explanation_model,
+        ),
+    )
+```
+
+### Config additions (`ops-pilot.yml`)
+
+```yaml
+trust:
+  explanation_model: claude-haiku-4-5-20251001  # cheaper model for explanation calls; defaults to main model
+```
+
+`OpsPilotConfig` gains `trust: TrustConfig` with:
+
+```python
+class TrustConfig(BaseModel):
+    explanation_model: str = ""   # empty = use same model as main agent
+```
+
+`make_trust_context()` resolves `explanation_model` to `config.model` when the field is empty.
+
+---
+
+## Component Detail
+
+### AuditLog
+
+File: `shared/audit_log.py`
+
+```python
+class AuditLog:
+    def record(
+        self,
+        *,
+        tenant_id: str,
+        actor: str,
+        tool_name: str,
+        tool_input: dict,
+        tool_result: str,
+        is_error: bool,
+        explanation: str | None,
+    ) -> None: ...
+```
+
+Each record is one JSON line:
+
+```json
+{
+  "ts": 1743686400.0,
+  "tenant_id": "acme-corp",
+  "actor": "FixAgent",
+  "tool_name": "update_file",
+  "tool_input": {"path": "auth/token.py", "content": "..."},
+  "tool_result": "File updated successfully",
+  "is_error": false,
+  "explanation": "Patching null-check at line 47 because the diff shows token.validate() was called before the guard was added in commit a1b2c3d."
+}
+```
+
+`explanation` is `null` for `READ_ONLY` and `WRITE` tools — only populated for `REQUIRES_CONFIRMATION`.
+
+Writes use POSIX atomic rename (same pattern as `UsageTracker` and `MemoryStore`). Write failures log a warning and return silently — a broken audit trail never stops an investigation.
+
+Storage: `audit/YYYY-MM-DD.jsonl` — one file per UTC calendar day. Directory created on first write.
+
+### ExplanationGenerator
+
+File: `shared/explanation_gen.py`
+
+```python
+class ExplanationGenerator:
+    def __init__(self, backend, model: str) -> None: ...
+
+    def generate(
+        self,
+        tool_name: str,
+        tool_input: dict,
+        context_summary: str,
+    ) -> str: ...
+```
+
+Makes one `backend.complete()` call with a concise prompt containing the tool name, sanitised arguments, and `context_summary` (the `last_assistant_text` at the point of the tool call — 2–3 sentences of what the investigation found so far). Returns a single plain-English sentence.
+
+On backend failure: logs a warning, returns `""` (empty string). Tool execution proceeds regardless — explanation generation is observability, not a gate.
+
+### escalation.py
+
+File: `shared/escalation.py`
+
+```python
+class EscalationSummary(BaseModel):
+    failure_id: str
+    tenant_id: str | None
+    what_was_investigated: str
+    what_was_inconclusive: str
+    recommended_next_step: str
+
+def generate_escalation_summary(
+    failure: Failure,
+    triage: Triage,
+    backend,
+    model: str,
+) -> EscalationSummary: ...
+```
+
+One `backend.complete()` call. Called from `run_pipeline.py` when `triage.fix_confidence == "LOW"`. Replaces the FixAgent path entirely for that investigation.
+
+On backend failure: returns a minimal `EscalationSummary` with `what_was_investigated` populated from `triage.output` directly — the pipeline never crashes.
+
+---
+
+## Integration Points
+
+| Location | Change |
+|---|---|
+| `AgentLoop.__init__` | Add `trust_context: TrustContext \| None = None` and `actor: str = "agent"` parameters |
+| `AgentLoop.run_one()` — before `REQUIRES_CONFIRMATION` execution | Call `trust_context.explanation_generator.generate(tool_name, tool_input, last_text)` |
+| `AgentLoop.run_one()` — after any tool execution | Call `trust_context.audit_log.record(...)` with all fields; `explanation` is `None` for non-confirmation tools |
+| `UpdateFileTool.permission` | Change return value from `Permission.WRITE` to `Permission.REQUIRES_CONFIRMATION` |
+| `OpenDraftPRTool.permission` | Change return value from `Permission.WRITE` to `Permission.REQUIRES_CONFIRMATION` |
+| `CreateBranchTool.permission` | No change — stays `Permission.WRITE` |
+| `run_pipeline.py` | After triage, branch on `fix_confidence`: LOW → `generate_escalation_summary()` + notify; else → existing FixAgent path |
+| `NotifyAgent` | Accept `fix: Fix \| None` and `escalation: EscalationSummary \| None`; render escalation format when fix is absent |
+| `OpsPilotConfig` | Add `trust: TrustConfig` field |
+| `run_pipeline.py` startup | Construct `trust_ctx = make_trust_context(config, backend)` alongside `tenant_ctx` |
+| `.gitignore` | Add `audit/` |
+
+---
+
+## Error Handling
+
+| Failure | Behaviour |
+|---|---|
+| `AuditLog` write fails | Log warning, continue — broken audit trail never stops an investigation |
+| `ExplanationGenerator` call fails | Log warning, set `explanation = None` in audit record, continue with tool execution |
+| `generate_escalation_summary` fails | Log error, return minimal `EscalationSummary` from `triage.output` directly |
+| `NotifyAgent` receives `EscalationSummary` with no fix | Renders escalation message format — no special error handling needed |
+
+---
+
+## Testing
+
+| Module | What to test |
+|---|---|
+| `AuditLog` | Record written correctly to daily file, daily file rollover (new UTC day = new file), atomic write pattern, silent failure on unwritable path |
+| `ExplanationGenerator` | Correct prompt constructed from tool name + input + context summary; backend called exactly once; backend failure returns empty string |
+| `escalation.py` | `EscalationSummary` fields populated from triage; backend called once; fallback summary returned on backend failure |
+| `TrustContext` | `make_trust_context()` passes backend reference to `ExplanationGenerator`; resolves empty `explanation_model` to `config.model` |
+| `AgentLoop` | Explanation generated before `REQUIRES_CONFIRMATION` tool; audit record written after every tool; no explanation call for `READ_ONLY`/`WRITE` tools; `actor` stamped on every audit record |
+| `run_pipeline.py` | LOW confidence skips FixAgent and calls `generate_escalation_summary`; MEDIUM/HIGH proceeds to FixAgent |
+| Tool promotions | `UpdateFileTool.permission == REQUIRES_CONFIRMATION`; `OpenDraftPRTool.permission == REQUIRES_CONFIRMATION`; `CreateBranchTool.permission == WRITE` |
+
+Target: 80% coverage on all new modules, consistent with existing standards.
+
+---
+
+## Storage Layout
+
+```
+audit/
+  2026-04-06.jsonl    # {"ts": ..., "tenant_id": ..., "actor": ..., "tool_name": ..., ...}
+  2026-04-07.jsonl
+```
+
+Both the `audit/` directory and its files are gitignored. The directory is created on first write.
+
+---
+
+## Future Upgrade Path
+
+Phase 8 (human-in-the-loop approval): replace the auto-proceed behaviour after explanation generation with a real approval gate. The seam is already in place — `AgentLoop`'s `confirm` hook is wired but always returns `True` implicitly in Phase 7 (execution proceeds after explanation). Phase 8 wires a real async approval callback there. Zero changes to `AuditLog`, `ExplanationGenerator`, or any tool definitions.

--- a/ops-pilot.yml
+++ b/ops-pilot.yml
@@ -12,6 +12,12 @@ github_token: ${GITHUB_TOKEN}
 # slack_bot_token: ${SLACK_BOT_TOKEN}
 # slack_webhook_url: ${SLACK_WEBHOOK_URL}
 
+# ── Trust & explainability (Phase 7) ─────────────────────────────────────────
+# Leave explanation_model empty to reuse the main model for pre-action explanations.
+# Set to a faster/cheaper model (e.g. claude-haiku-4-5-20251001) to reduce latency.
+trust:
+  explanation_model: ""
+
 # ── Watcher settings ──────────────────────────────────────────────────────────
 poll_interval_seconds: 30
 state_file: ops_pilot_state.json

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -31,10 +31,13 @@ from agents.triage_agent import TriageAgent
 from agents.fix_agent import FixAgent
 from agents.notify_agent import NotifyAgent
 from shared.config import load_config
+from shared.escalation import generate_escalation_summary
+from shared.llm_backend import make_backend
 from shared.memory_store import MemoryStore, make_memory_record
 from shared.task_queue import TaskQueue
 from shared.state_store import StateStore
 from shared.tenant_context import make_tenant_context
+from shared.trust_context import make_trust_context
 
 
 SCENARIOS_DIR = Path(__file__).parent / "demo" / "scenarios"
@@ -102,7 +105,9 @@ def run_pipeline(scenario_id: str, dry_run: bool = False) -> int:
 
     failure = load_scenario(scenario_id)
     config = load_config()
+    backend = make_backend(config)
     tenant_ctx = make_tenant_context(config)
+    trust_ctx = make_trust_context(config, backend)
     memory_store = MemoryStore()
     store = StateStore(path=f"ops_pilot_state_{scenario_id}.json")
     queue = TaskQueue()
@@ -127,7 +132,12 @@ def run_pipeline(scenario_id: str, dry_run: bool = False) -> int:
 
     t0 = time.time()
     model = os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
-    triage_agent = TriageAgent(model=model, tenant_context=tenant_ctx)
+    triage_agent = TriageAgent(
+        backend=backend,
+        model=model,
+        tenant_context=tenant_ctx,
+        trust_context=trust_ctx,
+    )
     triage = triage_agent.run(failure)
     elapsed = time.time() - t0
 
@@ -142,21 +152,34 @@ def run_pipeline(scenario_id: str, dry_run: bool = False) -> int:
     store.set(failure.id, "triage", triage.model_dump(mode="json"))
     queue.claim_next()
 
-    # ── 3. Fix ────────────────────────────────────────────────────────────────
-    banner("3 / 4  FIX", YELLOW)
-    step("fix", "Generating patch + PR description with Claude…")
+    # ── 3. Fix (or escalate) ──────────────────────────────────────────────────
+    fix = None
+    escalation = None
 
-    t0 = time.time()
-    fix_agent = FixAgent(model=model, demo_mode=True)  # demo_mode=True skips real GitHub API
-    fix = fix_agent.run(failure, triage)
-    elapsed = time.time() - t0
+    if triage.fix_confidence == "LOW":
+        banner("3 / 4  ESCALATE  (fix_confidence=LOW)", RED)
+        step("escalate", "Generating escalation summary — human review required…")
+        t0 = time.time()
+        escalation = generate_escalation_summary(failure, triage, backend=backend, model=model)
+        elapsed = time.time() - t0
+        step("escalate", f"Recommended: {escalation.recommended_next_step}")
+        step("escalate", f"Elapsed:     {elapsed:.1f}s  {YELLOW}⚠{RESET}")
+        store.set(failure.id, "escalation", escalation.model_dump(mode="json"))
+    else:
+        banner("3 / 4  FIX", YELLOW)
+        step("fix", "Generating patch + PR description with Claude…")
 
-    step("fix", f"PR title:  {BOLD}{fix.pr_title}{RESET}")
-    step("fix", f"PR URL:    {CYAN}{fix.pr_url}{RESET}")
-    step("fix", f"Elapsed:   {elapsed:.1f}s  {GREEN}✓{RESET}")
-    print(f"\n  {DIM}{fix.pr_body[:400]}{'…' if len(fix.pr_body) > 400 else ''}{RESET}\n")
+        t0 = time.time()
+        fix_agent = FixAgent(model=model, demo_mode=True)  # demo_mode=True skips real GitHub API
+        fix = fix_agent.run(failure, triage)
+        elapsed = time.time() - t0
 
-    store.set(failure.id, "fix", fix.model_dump(mode="json"))
+        step("fix", f"PR title:  {BOLD}{fix.pr_title}{RESET}")
+        step("fix", f"PR URL:    {CYAN}{fix.pr_url}{RESET}")
+        step("fix", f"Elapsed:   {elapsed:.1f}s  {GREEN}✓{RESET}")
+        print(f"\n  {DIM}{fix.pr_body[:400]}{'…' if len(fix.pr_body) > 400 else ''}{RESET}\n")
+
+        store.set(failure.id, "fix", fix.model_dump(mode="json"))
 
     # Record completed investigation to memory and usage tracker
     tenant_ctx.usage_tracker.record_incident()
@@ -170,7 +193,7 @@ def run_pipeline(scenario_id: str, dry_run: bool = False) -> int:
 
     t0 = time.time()
     notify_agent = NotifyAgent(model=model, demo_mode=True, channel="#platform-alerts")
-    alert = notify_agent.run(failure, triage, fix)
+    alert = notify_agent.run(failure, triage, fix=fix, escalation=escalation)
     elapsed = time.time() - t0
 
     step("notify", f"Channel:   {alert.channel}")

--- a/shared/agent_loop.py
+++ b/shared/agent_loop.py
@@ -35,6 +35,7 @@ from shared.tenant_context import TenantContext
 if TYPE_CHECKING:
     from providers.base import CIProvider
     from shared.models import Failure
+    from shared.trust_context import TrustContext
 
 logger = logging.getLogger(__name__)
 
@@ -270,6 +271,8 @@ class AgentLoop(Generic[T]):
         confirm: Callable[[Tool, dict], Awaitable[bool]] | None = None,
         context_budget: ContextBudget | None = None,
         tenant_context: TenantContext | None = None,
+        trust_context: TrustContext | None = None,
+        actor: str = "agent",
     ) -> None:
         self._tools: dict[str, Tool] = {t.name: t for t in tools}
         self._confirm = confirm
@@ -281,6 +284,8 @@ class AgentLoop(Generic[T]):
         self._max_tokens = max_tokens
         self._context_budget = context_budget
         self._tenant_context = tenant_context
+        self._trust_context = trust_context
+        self._actor = actor
 
         # Full system prompt = domain instructions + loop mechanics footer.
         # The schema is embedded in the footer so the model knows the shape
@@ -411,7 +416,7 @@ class AgentLoop(Generic[T]):
             # appended results one at a time as they finish, you'd get malformed
             # interleaved history. Execute everything, then do one append.
             tool_results = await self._execute_tools_concurrent(
-                tool_uses, ctx, failed_tools
+                tool_uses, ctx, failed_tools, last_text
             )
 
             # ── Step 5: Append one user message with ALL results ─────────────
@@ -455,6 +460,7 @@ class AgentLoop(Generic[T]):
         tool_uses: list[ToolUseBlock],
         ctx: ToolContext,
         failed_tools: list[str],  # mutated in-place to track cumulative failures
+        last_text: str = "",
     ) -> list[dict]:
         """Execute all tool calls concurrently; return results in original order.
 
@@ -462,18 +468,41 @@ class AgentLoop(Generic[T]):
         order. Result[i] always corresponds to tool_uses[i]. This matters because
         the API matches tool_result blocks to tool_use blocks by id, and the order
         must match the tool_use order in the preceding assistant message.
+
+        Args:
+            tool_uses:    Tool call blocks from the current assistant turn.
+            ctx:          Runtime context injected into tool.execute().
+            failed_tools: Cumulative list of errored tool names — mutated in-place.
+            last_text:    Last assistant text, used as context for explanation generation.
         """
         async def run_one(block: ToolUseBlock) -> dict:
             tool = self._tools.get(block.name)
+            tenant_id = (
+                self._tenant_context.tenant_id
+                if self._tenant_context is not None
+                else ""
+            )
+
             if tool is None:
                 failed_tools.append(block.name)
+                result_content = (
+                    f"Unknown tool '{block.name}'. "
+                    f"Available tools: {sorted(self._tools.keys())}"
+                )
+                if self._trust_context is not None:
+                    self._trust_context.audit_log.record(
+                        tenant_id=tenant_id,
+                        actor=self._actor,
+                        tool_name=block.name,
+                        tool_input=block.input,
+                        tool_result=result_content,
+                        is_error=True,
+                        explanation=None,
+                    )
                 return {
                     "type": "tool_result",
                     "tool_use_id": block.id,
-                    "content": (
-                        f"Unknown tool '{block.name}'. "
-                        f"Available tools: {sorted(self._tools.keys())}"
-                    ),
+                    "content": result_content,
                     "is_error": True,
                 }
 
@@ -484,72 +513,100 @@ class AgentLoop(Generic[T]):
                 and not self._tenant_context.permissions.is_allowed(block.name)
             ):
                 failed_tools.append(block.name)
+                result_content = (
+                    f"Tool '{block.name}' is not permitted for this deployment. "
+                    "Use an alternative tool or conclude without this data."
+                )
+                if self._trust_context is not None:
+                    self._trust_context.audit_log.record(
+                        tenant_id=tenant_id,
+                        actor=self._actor,
+                        tool_name=block.name,
+                        tool_input=block.input,
+                        tool_result=result_content,
+                        is_error=True,
+                        explanation=None,
+                    )
                 return {
                     "type": "tool_result",
                     "tool_use_id": block.id,
-                    "content": (
-                        f"Tool '{block.name}' is not permitted for this deployment. "
-                        "Use an alternative tool or conclude without this data."
-                    ),
+                    "content": result_content,
                     "is_error": True,
                 }
 
             # ── Confirmation gate ────────────────────────────────────────────
-            # REQUIRES_CONFIRMATION tools are blocked unless a confirm hook is
-            # wired and approves. Fail-safe: no hook → denied. The model receives
-            # a clear error message and can adapt (explain what it would do, ask
-            # for escalation, etc.). Never silently skip the tool_result — the
-            # API requires every tool_use to have a paired result.
+            # Phase 7: if trust_context is set, generate explanation and auto-proceed.
+            # Phase 8 will add a real approval gate here instead.
+            # Without trust_context, fall through to the existing confirm hook.
+            explanation: str | None = None
             if tool.permission == Permission.REQUIRES_CONFIRMATION:
-                approved = (
-                    self._confirm is not None
-                    and await self._confirm(tool, block.input)
-                )
-                if not approved:
-                    failed_tools.append(block.name)
-                    return {
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": (
-                            f"Tool '{block.name}' requires explicit confirmation "
-                            "before execution. No confirmation hook is configured "
-                            "— action blocked. Summarise what you intended to do "
-                            "and why, so a human can review and approve."
-                        ),
-                        "is_error": True,
-                    }
+                if self._trust_context is not None:
+                    explanation = self._trust_context.explanation_generator.generate(
+                        tool_name=block.name,
+                        tool_input=block.input,
+                        context_summary=last_text,
+                    )
+                    # auto-proceed — observability without blocking
+                else:
+                    approved = (
+                        self._confirm is not None
+                        and await self._confirm(tool, block.input)
+                    )
+                    if not approved:
+                        failed_tools.append(block.name)
+                        return {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": (
+                                f"Tool '{block.name}' requires explicit confirmation "
+                                "before execution. No confirmation hook is configured "
+                                "— action blocked. Summarise what you intended to do "
+                                "and why, so a human can review and approve."
+                            ),
+                            "is_error": True,
+                        }
 
+            # ── Execute ──────────────────────────────────────────────────────
+            is_error = False
+            result_content = ""
             try:
                 result = await asyncio.wait_for(
                     tool.execute(block.input, ctx),
                     timeout=self._tool_timeout,
                 )
+                is_error = result.is_error
+                result_content = result.content
                 if result.is_error:
                     failed_tools.append(block.name)
-                return {
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": result.content,
-                    **({"is_error": True} if result.is_error else {}),
-                }
             except TimeoutError:
                 failed_tools.append(block.name)
+                is_error = True
+                result_content = f"Tool timed out after {self._tool_timeout}s. Try requesting fewer lines."
                 logger.warning("Tool '%s' timed out after %.1fs", block.name, self._tool_timeout)
-                return {
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": f"Tool timed out after {self._tool_timeout}s. Try requesting fewer lines.",
-                    "is_error": True,
-                }
             except Exception as exc:
                 failed_tools.append(block.name)
+                is_error = True
+                result_content = f"Tool error: {exc}"
                 logger.warning("Tool '%s' raised: %s", block.name, exc)
-                return {
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": f"Tool error: {exc}",
-                    "is_error": True,
-                }
+
+            # ── Audit log ────────────────────────────────────────────────────
+            if self._trust_context is not None:
+                self._trust_context.audit_log.record(
+                    tenant_id=tenant_id,
+                    actor=self._actor,
+                    tool_name=block.name,
+                    tool_input=block.input,
+                    tool_result=result_content,
+                    is_error=is_error,
+                    explanation=explanation,
+                )
+
+            return {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": result_content,
+                **({"is_error": True} if is_error else {}),
+            }
 
         return list(await asyncio.gather(*[run_one(b) for b in tool_uses]))
 

--- a/shared/audit_log.py
+++ b/shared/audit_log.py
@@ -1,0 +1,101 @@
+"""Structured audit trail for ops-pilot tool calls.
+
+Writes one JSON record per tool call to audit/YYYY-MM-DD.jsonl.
+The file rolls over at UTC midnight. Writes are done via read-append-atomic-write
+so the JSONL file is never partially written.
+
+Write failures log a warning and return silently — a broken audit trail
+never stops an investigation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ── Atomic write helper ────────────────────────────────────────────────────────
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content to path via an atomic rename.
+
+    Uses tempfile.mkstemp in the same directory as the target so the rename
+    is always within a single filesystem (POSIX rename guarantee).
+
+    Args:
+        path:    Target file path. Parent directory must already exist.
+        content: Text content to write.
+    """
+    tmp_fd, tmp_path_str = tempfile.mkstemp(dir=path.parent, prefix=".tmp_audit_")
+    tmp_path = Path(tmp_path_str)
+    try:
+        with open(tmp_fd, "w") as f:
+            f.write(content)
+        tmp_path.rename(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+class AuditLog:
+    """Append-only per-day JSONL audit log for tool calls.
+
+    Args:
+        base_dir: Directory for audit files. Created on first write.
+                  Defaults to ./audit.
+    """
+
+    def __init__(self, base_dir: Path | str = Path("audit")) -> None:
+        self._base = Path(base_dir)
+
+    def record(
+        self,
+        *,
+        tenant_id: str,
+        actor: str,
+        tool_name: str,
+        tool_input: dict[str, object],
+        tool_result: str,
+        is_error: bool,
+        explanation: str | None,
+    ) -> None:
+        """Append one audit record to today's JSONL file.
+
+        Args:
+            tenant_id:   Deployment identifier — from TenantContext or "".
+            actor:       Agent name that made the tool call, e.g. "TriageAgent".
+            tool_name:   Tool name as registered in the tool registry.
+            tool_input:  Raw input dict the model sent.
+            tool_result: String result from the tool (or error message).
+            is_error:    True if the tool returned an error result.
+            explanation: Plain-English pre-action explanation for
+                         REQUIRES_CONFIRMATION tools. None for other tools.
+        """
+        entry = {
+            "ts": datetime.now(UTC).isoformat(),
+            "tenant_id": tenant_id,
+            "actor": actor,
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_result": tool_result,
+            "is_error": is_error,
+            "explanation": explanation,
+        }
+        try:
+            self._base.mkdir(parents=True, exist_ok=True)
+            date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+            target = self._base / f"{date_str}.jsonl"
+
+            # Read existing content, append new line, write atomically.
+            existing = target.read_text() if target.exists() else ""
+            new_content = existing + json.dumps(entry) + "\n"
+
+            _atomic_write(target, new_content)
+
+        except Exception as exc:
+            logger.warning("AuditLog: write failed — %s", exc)

--- a/shared/config.py
+++ b/shared/config.py
@@ -44,6 +44,18 @@ class RateLimitsConfig(BaseModel):
     )
 
 
+class TrustConfig(BaseModel):
+    """Trust and explainability configuration."""
+
+    explanation_model: str = Field(
+        default="",
+        description=(
+            "Model for pre-action explanation calls. "
+            "Empty string = use the same model as the main agent."
+        ),
+    )
+
+
 class PipelineConfig(BaseModel):
     """Configuration for a single monitored repository."""
 
@@ -147,6 +159,12 @@ class OpsPilotConfig(BaseModel):
     rate_limits: RateLimitsConfig = Field(
         default_factory=RateLimitsConfig,
         description="Per-deployment rate limiting configuration.",
+    )
+
+    # Trust and explainability
+    trust: TrustConfig = Field(
+        default_factory=TrustConfig,
+        description="Trust and explainability configuration.",
     )
 
     # AWS Bedrock

--- a/shared/escalation.py
+++ b/shared/escalation.py
@@ -1,0 +1,108 @@
+"""Escalation summary generation for LOW-confidence triage results.
+
+When TriageAgent returns fix_confidence: LOW, FixAgent is skipped entirely.
+This module generates a structured summary for the on-call engineer instead,
+explaining what was investigated, what remained inconclusive, and what to do next.
+
+On backend failure, a minimal EscalationSummary is constructed directly from
+triage.output so the pipeline never crashes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from pydantic import BaseModel
+
+from shared.llm_backend import LLMBackend
+from shared.models import Failure, Triage
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM = """You are generating an escalation summary for an on-call engineer.
+The automated agent investigated a CI failure but could not determine the root cause
+with sufficient confidence to apply a fix automatically.
+
+Output valid JSON only — no markdown fences. Schema:
+{
+  "failure_id": "<string>",
+  "tenant_id": "<string or null>",
+  "what_was_investigated": "<1-2 sentences: what the agent looked at>",
+  "what_was_inconclusive": "<1 sentence: what remained unclear>",
+  "recommended_next_step": "<1 sentence: what the engineer should do first>"
+}"""
+
+
+class EscalationSummary(BaseModel):
+    """Structured escalation summary for on-call engineers.
+
+    Generated when TriageAgent returns fix_confidence: LOW. Sent to the
+    engineer via NotifyAgent instead of a fix PR.
+    """
+
+    failure_id: str
+    tenant_id: str | None
+    what_was_investigated: str
+    what_was_inconclusive: str
+    recommended_next_step: str
+
+
+def generate_escalation_summary(
+    failure: Failure,
+    triage: Triage,
+    backend: LLMBackend,
+    model: str,
+) -> EscalationSummary:
+    """Generate a structured escalation summary from a LOW-confidence triage.
+
+    Makes one backend.complete() call to synthesize the escalation content.
+    On any failure, returns a minimal EscalationSummary built directly from
+    triage.output — the pipeline never crashes.
+
+    Args:
+        failure: Original CI failure payload.
+        triage:  Triage result with fix_confidence == "LOW".
+        backend: LLM backend for the summary call.
+        model:   Model identifier.
+
+    Returns:
+        EscalationSummary with investigation context for the engineer.
+    """
+    user = (
+        f"CI failure in {failure.pipeline.repo} — job '{failure.failure.job}', "
+        f"step '{failure.failure.step}', commit {failure.pipeline.commit}.\n\n"
+        f"Triage findings:\n{triage.output}\n\n"
+        f"Severity: {triage.severity.value.upper()}\n"
+        f"Affected service: {triage.affected_service}\n"
+        f"Fix confidence: {triage.fix_confidence}\n\n"
+        f"Generate the escalation summary JSON."
+    )
+    fallback = EscalationSummary(
+        failure_id=failure.id,
+        tenant_id=None,
+        what_was_investigated=triage.output,
+        what_was_inconclusive="Root cause could not be determined with sufficient confidence.",
+        recommended_next_step=(
+            f"Manually inspect the '{failure.failure.job}' job logs for commit "
+            f"{failure.pipeline.commit} in {failure.pipeline.repo}."
+        ),
+    )
+    try:
+        raw = backend.complete(
+            system=_SYSTEM,
+            user=user,
+            model=model,
+            max_tokens=512,
+        ).strip()
+        if raw.startswith("```"):
+            raw = "\n".join(
+                line for line in raw.splitlines() if not line.startswith("```")
+            ).strip()
+        data = json.loads(raw)
+        data.setdefault("failure_id", failure.id)
+        data.setdefault("tenant_id", None)
+        return EscalationSummary(**data)
+    except Exception as exc:
+        logger.error("generate_escalation_summary: failed — %s", exc)
+        return fallback

--- a/shared/explanation_gen.py
+++ b/shared/explanation_gen.py
@@ -1,0 +1,74 @@
+"""LLM-backed pre-action explanation generator for REQUIRES_CONFIRMATION tools.
+
+Called once before each REQUIRES_CONFIRMATION tool execution when a
+TrustContext is present. Returns a single plain-English sentence describing
+what the agent is about to do and why.
+
+This is observability infrastructure — it must never block tool execution.
+Backend failures return "" and the tool runs regardless.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from shared.llm_backend import LLMBackend
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM = (
+    "You are explaining what an automated CI agent is about to do to an engineering team. "
+    "Write exactly one plain-English sentence describing the action and the reason for it. "
+    "Be specific: include the file path or PR title if present. No markdown, no lists."
+)
+
+
+class ExplanationGenerator:
+    """Generates a plain-English explanation before a REQUIRES_CONFIRMATION tool executes.
+
+    Args:
+        backend: LLM backend instance (same interface as agents use).
+        model:   Model identifier to use for explanation calls. Should be a
+                 cheap, fast model (e.g. Haiku) since this runs before every
+                 dangerous tool call.
+    """
+
+    def __init__(self, backend: LLMBackend, model: str) -> None:
+        self._backend = backend
+        self._model = model
+
+    def generate(
+        self,
+        tool_name: str,
+        tool_input: dict[str, object],
+        context_summary: str,
+    ) -> str:
+        """Generate a plain-English explanation for an imminent tool call.
+
+        Args:
+            tool_name:       Registered tool name, e.g. "update_file".
+            tool_input:      The input dict the model is about to send.
+            context_summary: Last assistant text from the investigation
+                             (2-3 sentences of what was found so far).
+
+        Returns:
+            A single plain-English sentence. Returns "" on backend failure.
+        """
+        sanitized_input = json.dumps(tool_input, default=str)
+        user = (
+            f"The agent is about to call tool '{tool_name}' with these arguments:\n"
+            f"{sanitized_input}\n\n"
+            f"Investigation context:\n{context_summary}\n\n"
+            f"Write one sentence explaining what will happen and why."
+        )
+        try:
+            return self._backend.complete(
+                system=_SYSTEM,
+                user=user,
+                model=self._model,
+                max_tokens=128,
+            ).strip()
+        except Exception as exc:
+            logger.warning("ExplanationGenerator: backend call failed — %s", exc)
+            return ""

--- a/shared/trust_context.py
+++ b/shared/trust_context.py
@@ -1,0 +1,61 @@
+"""TrustContext — bundles audit log and explanation generator for Phase 7.
+
+Constructed once at startup by make_trust_context() and injected into
+AgentLoop alongside TenantContext. Follows the same injection pattern used
+throughout Phases 5 and 6.
+
+Phase 8 upgrade path: when human-in-the-loop approval is added, it plugs in
+here — zero changes to AuditLog, ExplanationGenerator, or any tool definitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from shared.audit_log import AuditLog
+from shared.explanation_gen import ExplanationGenerator
+from shared.llm_backend import LLMBackend
+
+if TYPE_CHECKING:
+    from shared.config import OpsPilotConfig
+
+
+@dataclass
+class TrustContext:
+    """Runtime trust infrastructure for one agent loop.
+
+    Attributes:
+        audit_log:             Appends one record per tool call to the daily JSONL file.
+        explanation_generator: Generates pre-action explanations for REQUIRES_CONFIRMATION tools.
+    """
+
+    audit_log: AuditLog
+    explanation_generator: ExplanationGenerator
+
+
+def make_trust_context(config: OpsPilotConfig, backend: LLMBackend) -> TrustContext:
+    """Construct a TrustContext from an OpsPilotConfig and a shared backend.
+
+    The backend is the same instance used by the calling agent — no extra
+    authentication is needed, and test doubles are injected here.
+
+    The explanation_model falls back to config.model when left empty in config,
+    so operators can omit the field without losing functionality.
+
+    Args:
+        config:  OpsPilotConfig instance with optional trust.explanation_model.
+        backend: LLM backend shared with the calling agent.
+
+    Returns:
+        Fully wired TrustContext ready for injection into AgentLoop.
+    """
+    explanation_model = config.trust.explanation_model or config.model  # type: ignore[attr-defined]
+    return TrustContext(
+        audit_log=AuditLog(base_dir=Path("audit")),
+        explanation_generator=ExplanationGenerator(
+            backend=backend,
+            model=explanation_model,
+        ),
+    )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -889,3 +889,204 @@ class TestTenantContext:
         )
         assert len(tool.calls) == 1
         assert "record" not in result.failed_tools
+
+# ── Tests: TrustContext integration ───────────────────────────────────────────
+
+from shared.audit_log import AuditLog
+from shared.explanation_gen import ExplanationGenerator
+from shared.trust_context import TrustContext
+
+
+def _make_trust_context(
+    explanation_return: str = "About to patch auth.py.",
+    explanation_raises: bool = False,
+) -> TrustContext:
+    """Build a TrustContext with mock audit_log and explanation_generator."""
+    audit_log = MagicMock(spec=AuditLog)
+    explanation_gen = MagicMock(spec=ExplanationGenerator)
+    if explanation_raises:
+        explanation_gen.generate.side_effect = RuntimeError("backend down")
+    else:
+        explanation_gen.generate.return_value = explanation_return
+    return TrustContext(audit_log=audit_log, explanation_generator=explanation_gen)
+
+
+class TestTrustContextIntegration:
+    async def test_audit_record_written_after_every_tool_call(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """AuditLog.record() is called once for each tool execution."""
+        trust_ctx = _make_trust_context()
+        tool = RecordingTool("get_file")
+        backend = _make_backend([
+            _response(_tool_block("get_file", {"path": "auth.py"}, "t1")),
+            _response(_tool_block("get_file", {"path": "token.py"}, "t2")),
+            _end_turn(),
+        ])
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            max_turns=5,
+            trust_context=trust_ctx,
+            actor="TriageAgent",
+        )
+        await loop.run(messages=[{"role": "user", "content": "go"}], ctx=tool_ctx)
+        assert trust_ctx.audit_log.record.call_count == 2
+
+    async def test_actor_stamped_on_audit_records(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """The actor parameter is passed to every audit record."""
+        trust_ctx = _make_trust_context()
+        tool = RecordingTool("get_file")
+        backend = _make_backend([
+            _response(_tool_block("get_file", {}, "t1")),
+            _end_turn(),
+        ])
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            trust_context=trust_ctx,
+            actor="FixAgent",
+        )
+        await loop.run(messages=[{"role": "user", "content": "go"}], ctx=tool_ctx)
+        call_kwargs = trust_ctx.audit_log.record.call_args[1]
+        assert call_kwargs["actor"] == "FixAgent"
+
+    async def test_explanation_generated_before_requires_confirmation_tool(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """ExplanationGenerator.generate() is called before REQUIRES_CONFIRMATION tools."""
+        trust_ctx = _make_trust_context()
+        tool = ConfirmationTool()
+        backend = _make_backend([
+            _response(_tool_block("confirm_action", {}, "t1")),
+            _end_turn(),
+        ])
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            max_turns=5,
+            trust_context=trust_ctx,
+        )
+        await loop.run(messages=[{"role": "user", "content": "go"}], ctx=tool_ctx)
+        trust_ctx.explanation_generator.generate.assert_called_once()
+        assert tool.executed
+
+    async def test_no_explanation_for_read_only_tools(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """ExplanationGenerator.generate() is NOT called for READ_ONLY tools."""
+        trust_ctx = _make_trust_context()
+        tool = RecordingTool("safe_read")
+        backend = _make_backend([
+            _response(_tool_block("safe_read", {}, "t1")),
+            _end_turn(),
+        ])
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            trust_context=trust_ctx,
+        )
+        await loop.run(messages=[{"role": "user", "content": "go"}], ctx=tool_ctx)
+        trust_ctx.explanation_generator.generate.assert_not_called()
+        assert trust_ctx.audit_log.record.call_count == 1
+
+    async def test_requires_confirmation_auto_proceeds_with_trust_context(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """When trust_context is set, REQUIRES_CONFIRMATION tools auto-proceed."""
+        trust_ctx = _make_trust_context()
+        tool = ConfirmationTool()
+        backend = _make_backend([
+            _response(_tool_block("confirm_action", {}, "t1")),
+            _end_turn(),
+        ])
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            max_turns=5,
+            trust_context=trust_ctx,
+            confirm=None,
+        )
+        result = await loop.run(
+            messages=[{"role": "user", "content": "go"}], ctx=tool_ctx
+        )
+        assert tool.executed
+        assert "confirm_action" not in result.failed_tools
+
+    async def test_requires_confirmation_still_blocked_without_trust_context(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """Without trust_context, REQUIRES_CONFIRMATION behavior is unchanged."""
+        tool = ConfirmationTool()
+        backend = _make_backend([
+            _response(_tool_block("confirm_action", {}, "t1")),
+            _end_turn(),
+        ])
+        loop = _make_loop(tools=[tool], backend=backend)
+        result = await loop.run(
+            messages=[{"role": "user", "content": "go"}], ctx=tool_ctx
+        )
+        assert not tool.executed
+        assert "confirm_action" in result.failed_tools
+
+    async def test_explanation_recorded_in_audit_for_confirmation_tool(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """Audit record for REQUIRES_CONFIRMATION tool includes explanation."""
+        trust_ctx = _make_trust_context(explanation_return="Patching auth.py line 47.")
+        tool = ConfirmationTool()
+        backend = _make_backend([
+            _response(_tool_block("confirm_action", {}, "t1")),
+            _end_turn(),
+        ])
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            max_turns=5,
+            trust_context=trust_ctx,
+        )
+        await loop.run(messages=[{"role": "user", "content": "go"}], ctx=tool_ctx)
+        call_kwargs = trust_ctx.audit_log.record.call_args[1]
+        assert call_kwargs["explanation"] == "Patching auth.py line 47."
+
+    async def test_audit_explanation_is_none_for_read_only_tools(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """Audit record for READ_ONLY tool has explanation=None."""
+        trust_ctx = _make_trust_context()
+        tool = RecordingTool("safe_read")
+        backend = _make_backend([
+            _response(_tool_block("safe_read", {}, "t1")),
+            _end_turn(),
+        ])
+        loop = AgentLoop(
+            tools=[tool],
+            backend=backend,
+            domain_system_prompt="test",
+            response_model=Finding,
+            model="claude-sonnet-4-6",
+            trust_context=trust_ctx,
+        )
+        await loop.run(messages=[{"role": "user", "content": "go"}], ctx=tool_ctx)
+        call_kwargs = trust_ctx.audit_log.record.call_args[1]
+        assert call_kwargs["explanation"] is None

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -34,11 +34,14 @@ from shared.agent_loop import (
     ToolContext,
     ToolResult,
 )
+from shared.audit_log import AuditLog
 from shared.exceptions import RateLimitExceeded
+from shared.explanation_gen import ExplanationGenerator
 from shared.models import DiffSummary, Failure, FailureDetail, PipelineInfo
 from shared.rate_limiter import RateLimiter
 from shared.tenant_context import TenantContext
 from shared.tool_permissions import ToolPermissions
+from shared.trust_context import TrustContext
 from shared.usage_tracker import UsageTracker
 
 # ── Minimal Pydantic model used as response_model in tests ────────────────────
@@ -891,10 +894,6 @@ class TestTenantContext:
         assert "record" not in result.failed_tools
 
 # ── Tests: TrustContext integration ───────────────────────────────────────────
-
-from shared.audit_log import AuditLog
-from shared.explanation_gen import ExplanationGenerator
-from shared.trust_context import TrustContext
 
 
 def _make_trust_context(

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,117 @@
+"""Tests for AuditLog — structured per-day JSONL audit trail."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from shared.audit_log import AuditLog
+
+
+@pytest.fixture
+def audit_dir(tmp_path: Path) -> Path:
+    return tmp_path / "audit"
+
+
+class TestAuditLogRecord:
+    def test_creates_daily_file_on_first_write(self, audit_dir: Path) -> None:
+        log = AuditLog(base_dir=audit_dir)
+        log.record(
+            tenant_id="acme",
+            actor="TriageAgent",
+            tool_name="get_file",
+            tool_input={"path": "auth.py"},
+            tool_result="file contents",
+            is_error=False,
+            explanation=None,
+        )
+        daily_files = list(audit_dir.glob("*.jsonl"))
+        assert len(daily_files) == 1
+
+    def test_record_is_valid_json_line(self, audit_dir: Path) -> None:
+        log = AuditLog(base_dir=audit_dir)
+        log.record(
+            tenant_id="acme",
+            actor="FixAgent",
+            tool_name="update_file",
+            tool_input={"path": "auth.py", "content": "fixed"},
+            tool_result="File updated successfully",
+            is_error=False,
+            explanation="Patching null-check at line 47.",
+        )
+        daily_file = next(audit_dir.glob("*.jsonl"))
+        lines = [line for line in daily_file.read_text().splitlines() if line.strip()]
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["tenant_id"] == "acme"
+        assert entry["actor"] == "FixAgent"
+        assert entry["tool_name"] == "update_file"
+        assert entry["tool_input"] == {"path": "auth.py", "content": "fixed"}
+        assert entry["tool_result"] == "File updated successfully"
+        assert entry["is_error"] is False
+        assert entry["explanation"] == "Patching null-check at line 47."
+        assert "ts" in entry
+
+    def test_explanation_none_for_read_only_tools(self, audit_dir: Path) -> None:
+        log = AuditLog(base_dir=audit_dir)
+        log.record(
+            tenant_id="t1",
+            actor="TriageAgent",
+            tool_name="get_file",
+            tool_input={},
+            tool_result="content",
+            is_error=False,
+            explanation=None,
+        )
+        entry = json.loads(next(audit_dir.glob("*.jsonl")).read_text().strip())
+        assert entry["explanation"] is None
+
+    def test_multiple_records_append_to_same_daily_file(self, audit_dir: Path) -> None:
+        log = AuditLog(base_dir=audit_dir)
+        for i in range(3):
+            log.record(
+                tenant_id="t1",
+                actor="TriageAgent",
+                tool_name=f"tool_{i}",
+                tool_input={},
+                tool_result="ok",
+                is_error=False,
+                explanation=None,
+            )
+        daily_file = next(audit_dir.glob("*.jsonl"))
+        lines = [line for line in daily_file.read_text().splitlines() if line.strip()]
+        assert len(lines) == 3
+        for line in lines:
+            json.loads(line)  # every line must be valid JSON
+
+    def test_is_error_true_recorded(self, audit_dir: Path) -> None:
+        log = AuditLog(base_dir=audit_dir)
+        log.record(
+            tenant_id="t1",
+            actor="TriageAgent",
+            tool_name="get_file",
+            tool_input={},
+            tool_result="Error: not found",
+            is_error=True,
+            explanation=None,
+        )
+        entry = json.loads(next(audit_dir.glob("*.jsonl")).read_text().strip())
+        assert entry["is_error"] is True
+
+    def test_write_failure_does_not_raise(self, tmp_path: Path) -> None:
+        # Point to a path where we cannot write (a file, not a dir)
+        blocker = tmp_path / "audit"
+        blocker.write_text("I am a file, not a directory")
+        log = AuditLog(base_dir=blocker / "subdir")
+        # Should not raise
+        log.record(
+            tenant_id="t1",
+            actor="agent",
+            tool_name="get_file",
+            tool_input={},
+            tool_result="ok",
+            is_error=False,
+            explanation=None,
+        )

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -1,0 +1,142 @@
+"""Tests for escalation — LOW-confidence escalation summary generation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.escalation import EscalationSummary, generate_escalation_summary
+from shared.models import DiffSummary, Failure, FailureDetail, PipelineInfo, Severity, Triage
+
+
+@pytest.fixture
+def failure() -> Failure:
+    return Failure(
+        id="esc_test_001",
+        pipeline=PipelineInfo(
+            provider="github_actions",
+            repo="acme/backend",
+            workflow="ci.yml",
+            run_id="12345",
+            branch="main",
+            commit="abc1234",
+            commit_message="chore: bump deps",
+            author="dev@acme.com",
+            triggered_at=datetime(2026, 4, 6),
+            failed_at=datetime(2026, 4, 6),
+            duration_seconds=60,
+        ),
+        failure=FailureDetail(
+            job="test-auth",
+            step="pytest",
+            exit_code=1,
+            log_tail=["FAILED test_auth.py::test_login"],
+        ),
+        diff_summary=DiffSummary(
+            files_changed=["auth.py"],
+            lines_added=5,
+            lines_removed=2,
+            key_change="removed null guard",
+        ),
+    )
+
+
+@pytest.fixture
+def low_confidence_triage(failure: Failure) -> Triage:
+    return Triage(
+        failure_id=failure.id,
+        output="Unable to determine root cause — Redis connection state unclear.",
+        severity=Severity.HIGH,
+        affected_service="auth-service",
+        regression_introduced_in="abc1234",
+        production_impact=None,
+        fix_confidence="LOW",
+        timestamp=datetime(2026, 4, 6),
+    )
+
+
+class TestEscalationSummary:
+    def test_is_pydantic_model(self) -> None:
+        from pydantic import BaseModel
+        assert issubclass(EscalationSummary, BaseModel)
+
+    def test_has_required_fields(self) -> None:
+        s = EscalationSummary(
+            failure_id="f1",
+            tenant_id="acme",
+            what_was_investigated="Auth failures",
+            what_was_inconclusive="Redis state",
+            recommended_next_step="Check Redis logs manually",
+        )
+        assert s.failure_id == "f1"
+        assert s.tenant_id == "acme"
+
+
+class TestGenerateEscalationSummary:
+    def test_calls_backend_once(
+        self, failure: Failure, low_confidence_triage: Triage
+    ) -> None:
+        backend = MagicMock()
+        backend.complete.return_value = (
+            '{"failure_id": "esc_test_001", "tenant_id": null, '
+            '"what_was_investigated": "Auth failures", '
+            '"what_was_inconclusive": "Redis state", '
+            '"recommended_next_step": "Check Redis logs"}'
+        )
+        result = generate_escalation_summary(
+            failure=failure,
+            triage=low_confidence_triage,
+            backend=backend,
+            model="claude-haiku-4-5-20251001",
+        )
+        backend.complete.assert_called_once()
+        assert isinstance(result, EscalationSummary)
+
+    def test_returns_escalation_summary_with_correct_failure_id(
+        self, failure: Failure, low_confidence_triage: Triage
+    ) -> None:
+        backend = MagicMock()
+        backend.complete.return_value = (
+            '{"failure_id": "esc_test_001", "tenant_id": null, '
+            '"what_was_investigated": "Auth failures in test-auth step", '
+            '"what_was_inconclusive": "Redis connection state", '
+            '"recommended_next_step": "Check Redis logs"}'
+        )
+        result = generate_escalation_summary(
+            failure=failure,
+            triage=low_confidence_triage,
+            backend=backend,
+            model="claude-haiku-4-5-20251001",
+        )
+        assert result.failure_id == "esc_test_001"
+
+    def test_backend_failure_returns_minimal_summary(
+        self, failure: Failure, low_confidence_triage: Triage
+    ) -> None:
+        backend = MagicMock()
+        backend.complete.side_effect = RuntimeError("API down")
+        result = generate_escalation_summary(
+            failure=failure,
+            triage=low_confidence_triage,
+            backend=backend,
+            model="claude-haiku-4-5-20251001",
+        )
+        assert isinstance(result, EscalationSummary)
+        assert result.failure_id == failure.id
+        assert low_confidence_triage.output in result.what_was_investigated
+
+    def test_invalid_json_from_backend_returns_minimal_summary(
+        self, failure: Failure, low_confidence_triage: Triage
+    ) -> None:
+        backend = MagicMock()
+        backend.complete.return_value = "not valid json {{"
+        result = generate_escalation_summary(
+            failure=failure,
+            triage=low_confidence_triage,
+            backend=backend,
+            model="claude-haiku-4-5-20251001",
+        )
+        assert isinstance(result, EscalationSummary)
+        assert result.failure_id == failure.id

--- a/tests/test_explanation_gen.py
+++ b/tests/test_explanation_gen.py
@@ -1,0 +1,74 @@
+"""Tests for ExplanationGenerator — LLM-backed pre-action explanations."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.explanation_gen import ExplanationGenerator
+
+
+@pytest.fixture
+def backend() -> MagicMock:
+    b = MagicMock()
+    b.complete.return_value = "Patching null-check at line 47 to restore the guard."
+    return b
+
+
+class TestExplanationGenerator:
+    def test_returns_string(self, backend: MagicMock) -> None:
+        gen = ExplanationGenerator(backend=backend, model="claude-haiku-4-5-20251001")
+        result = gen.generate(
+            tool_name="update_file",
+            tool_input={"path": "auth.py", "content": "fixed content"},
+            context_summary="Found null pointer at line 47 in auth.py.",
+        )
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_calls_backend_once(self, backend: MagicMock) -> None:
+        gen = ExplanationGenerator(backend=backend, model="claude-haiku-4-5-20251001")
+        gen.generate(
+            tool_name="update_file",
+            tool_input={"path": "auth.py"},
+            context_summary="context",
+        )
+        backend.complete.assert_called_once()
+
+    def test_prompt_includes_tool_name(self, backend: MagicMock) -> None:
+        gen = ExplanationGenerator(backend=backend, model="claude-haiku-4-5-20251001")
+        gen.generate(
+            tool_name="open_draft_pr",
+            tool_input={"title": "fix: restore guard"},
+            context_summary="context",
+        )
+        call_kwargs = backend.complete.call_args[1]
+        assert "open_draft_pr" in call_kwargs["user"]
+
+    def test_prompt_includes_context_summary(self, backend: MagicMock) -> None:
+        gen = ExplanationGenerator(backend=backend, model="claude-haiku-4-5-20251001")
+        gen.generate(
+            tool_name="update_file",
+            tool_input={},
+            context_summary="Found null pointer at line 47.",
+        )
+        call_kwargs = backend.complete.call_args[1]
+        assert "Found null pointer at line 47." in call_kwargs["user"]
+
+    def test_backend_failure_returns_empty_string(self) -> None:
+        bad_backend = MagicMock()
+        bad_backend.complete.side_effect = RuntimeError("API down")
+        gen = ExplanationGenerator(backend=bad_backend, model="claude-haiku-4-5-20251001")
+        result = gen.generate(
+            tool_name="update_file",
+            tool_input={},
+            context_summary="context",
+        )
+        assert result == ""
+
+    def test_uses_model_passed_to_constructor(self, backend: MagicMock) -> None:
+        gen = ExplanationGenerator(backend=backend, model="claude-haiku-4-5-20251001")
+        gen.generate(tool_name="update_file", tool_input={}, context_summary="ctx")
+        call_kwargs = backend.complete.call_args[1]
+        assert call_kwargs["model"] == "claude-haiku-4-5-20251001"

--- a/tests/test_fix_tools.py
+++ b/tests/test_fix_tools.py
@@ -177,8 +177,8 @@ class TestCreateBranchTool:
 # ── UpdateFileTool ─────────────────────────────────────────────────────────────
 
 class TestUpdateFileTool:
-    def test_permission_is_write(self) -> None:
-        assert UpdateFileTool().permission == Permission.WRITE
+    def test_permission_is_requires_confirmation(self) -> None:
+        assert UpdateFileTool().permission == Permission.REQUIRES_CONFIRMATION
 
     async def test_commits_file_via_provider(
         self, ctx: ToolContext, mock_provider: MagicMock
@@ -256,8 +256,8 @@ class TestUpdateFileTool:
 # ── OpenDraftPRTool ────────────────────────────────────────────────────────────
 
 class TestOpenDraftPRTool:
-    def test_permission_is_write(self) -> None:
-        assert OpenDraftPRTool().permission == Permission.WRITE
+    def test_permission_is_requires_confirmation(self) -> None:
+        assert OpenDraftPRTool().permission == Permission.REQUIRES_CONFIRMATION
 
     async def test_opens_pr_via_provider(
         self, ctx: ToolContext, mock_provider: MagicMock

--- a/tests/test_notify_agent.py
+++ b/tests/test_notify_agent.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agents.notify_agent import SEVERITY_EMOJI, NotifyAgent
+from shared.escalation import EscalationSummary
 from shared.models import AgentStatus, Failure, Severity
 
 
@@ -102,3 +103,65 @@ class TestSeverityEmoji:
 
     def test_critical_is_rotating_light(self):
         assert "rotating" in SEVERITY_EMOJI[Severity.CRITICAL]
+
+
+class TestNotifyAgentEscalation:
+    """Tests for the escalation path (fix_confidence == LOW, no fix produced)."""
+
+    def _make_escalation(self, failure_id: str = "fail-1") -> EscalationSummary:
+        return EscalationSummary(
+            failure_id=failure_id,
+            tenant_id="test-tenant",
+            what_was_investigated="Checked logs and diff for root cause",
+            what_was_inconclusive="Could not pinpoint the exact failing assertion",
+            recommended_next_step="Review test output manually and run locally",
+        )
+
+    def test_both_none_raises_value_error(
+        self,
+        sample_failure: Failure,
+        sample_triage,
+        mock_backend,
+    ) -> None:
+        agent = NotifyAgent(backend=mock_backend, demo_mode=True)
+        with pytest.raises(ValueError, match="both are None"):
+            agent.run(sample_failure, sample_triage, fix=None, escalation=None)
+
+    def test_escalation_path_returns_alert(
+        self,
+        sample_failure: Failure,
+        sample_triage,
+        mock_backend,
+    ) -> None:
+        mock_backend.complete.return_value = ":red_circle: Human review needed"
+        agent = NotifyAgent(backend=mock_backend, demo_mode=True)
+        escalation = self._make_escalation(failure_id=sample_failure.id)
+        alert = agent.run(sample_failure, sample_triage, fix=None, escalation=escalation)
+        assert alert.failure_id == sample_failure.id
+
+    def test_escalation_path_sets_status_complete(
+        self,
+        sample_failure: Failure,
+        sample_triage,
+        mock_backend,
+    ) -> None:
+        mock_backend.complete.return_value = "escalation msg"
+        agent = NotifyAgent(backend=mock_backend, demo_mode=True)
+        agent.run(sample_failure, sample_triage, fix=None, escalation=self._make_escalation())
+        assert agent.status == AgentStatus.COMPLETE
+
+    def test_escalation_message_includes_recommended_step(
+        self,
+        sample_failure: Failure,
+        sample_triage,
+        mock_backend,
+    ) -> None:
+        """Verify the LLM prompt includes the recommended_next_step."""
+        mock_backend.complete.return_value = "escalation alert"
+        agent = NotifyAgent(backend=mock_backend, demo_mode=True)
+        escalation = self._make_escalation()
+        agent.run(sample_failure, sample_triage, fix=None, escalation=escalation)
+        call_kwargs = mock_backend.complete.call_args
+        # The user message should mention the recommended step
+        user_msg = call_kwargs[1]["user"] if call_kwargs[1] else call_kwargs[0][1]
+        assert escalation.recommended_next_step in user_msg

--- a/tests/test_trust_context.py
+++ b/tests/test_trust_context.py
@@ -1,0 +1,68 @@
+"""Tests for TrustContext and make_trust_context."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from shared.audit_log import AuditLog
+from shared.config import OpsPilotConfig, TrustConfig
+from shared.explanation_gen import ExplanationGenerator
+from shared.trust_context import TrustContext, make_trust_context
+
+
+class TestTrustConfig:
+    def test_default_explanation_model_is_empty_string(self) -> None:
+        cfg = TrustConfig()
+        assert cfg.explanation_model == ""
+
+    def test_explanation_model_can_be_set(self) -> None:
+        cfg = TrustConfig(explanation_model="claude-haiku-4-5-20251001")
+        assert cfg.explanation_model == "claude-haiku-4-5-20251001"
+
+
+class TestOpsPilotConfigTrustField:
+    def test_ops_pilot_config_has_trust_field(self) -> None:
+        cfg = OpsPilotConfig()
+        assert hasattr(cfg, "trust")
+        assert isinstance(cfg.trust, TrustConfig)
+
+
+class TestMakeTrustContext:
+    def test_returns_trust_context(self) -> None:
+        config = OpsPilotConfig()
+        backend = MagicMock()
+        ctx = make_trust_context(config, backend)
+        assert isinstance(ctx, TrustContext)
+
+    def test_audit_log_is_audit_log_instance(self) -> None:
+        config = OpsPilotConfig()
+        backend = MagicMock()
+        ctx = make_trust_context(config, backend)
+        assert isinstance(ctx.audit_log, AuditLog)
+
+    def test_explanation_generator_is_explanation_generator_instance(self) -> None:
+        config = OpsPilotConfig()
+        backend = MagicMock()
+        ctx = make_trust_context(config, backend)
+        assert isinstance(ctx.explanation_generator, ExplanationGenerator)
+
+    def test_empty_explanation_model_resolves_to_config_model(self) -> None:
+        config = OpsPilotConfig(model="claude-sonnet-4-6")
+        backend = MagicMock()
+        ctx = make_trust_context(config, backend)
+        assert ctx.explanation_generator._model == "claude-sonnet-4-6"
+
+    def test_explicit_explanation_model_used_when_set(self) -> None:
+        config = OpsPilotConfig(
+            model="claude-sonnet-4-6",
+            trust=TrustConfig(explanation_model="claude-haiku-4-5-20251001"),
+        )
+        backend = MagicMock()
+        ctx = make_trust_context(config, backend)
+        assert ctx.explanation_generator._model == "claude-haiku-4-5-20251001"
+
+    def test_backend_reference_passed_to_explanation_generator(self) -> None:
+        config = OpsPilotConfig()
+        backend = MagicMock()
+        ctx = make_trust_context(config, backend)
+        assert ctx.explanation_generator._backend is backend


### PR DESCRIPTION
## Summary

- **AuditLog** (`shared/audit_log.py`): per-day JSONL audit trail — one structured record per tool call (tenant, actor, tool name, inputs, result, timestamp, pre-action explanation). Atomic writes via `mkstemp` + `rename`.
- **ExplanationGenerator** (`shared/explanation_gen.py`): fires a separate LLM call before any `REQUIRES_CONFIRMATION` tool executes, generating a human-readable rationale stored in the audit record. Never blocks execution — exceptions return `""`.
- **EscalationSummary** (`shared/escalation.py`): when `fix_confidence == LOW`, generates a structured summary (what was investigated, what was inconclusive, recommended next step) instead of guessing a fix.
- **TrustConfig + TrustContext** (`shared/config.py`, `shared/trust_context.py`): `TrustConfig` adds an optional `explanation_model` to `ops-pilot.yml` (empty = reuse main model). `TrustContext` bundles `AuditLog` + `ExplanationGenerator` and is injected into `AgentLoop` following the same pattern as `TenantContext`.
- **AgentLoop integration** (`shared/agent_loop.py`): every tool call is audited; `REQUIRES_CONFIRMATION` tools get a pre-action explanation generated then auto-proceed (observability layer, not an approval gate — Phase 8 adds the blocking confirm hook).
- **Tool permission promotions** (`agents/tools/fix_tools.py`): `UpdateFileTool` and `OpenDraftPRTool` promoted from `WRITE` to `REQUIRES_CONFIRMATION` — file commits and PR opens now generate explanations and appear distinctly in the audit log.
- **NotifyAgent escalation path** (`agents/notify_agent.py`): `run()` now accepts `fix: Fix | None` + `escalation: EscalationSummary | None`. Sends a purpose-built "human review required" Slack message on the LOW-confidence path. Raises `ValueError` if both are `None`.
- **End-to-end wiring** (`agents/triage_agent.py`, `run_pipeline.py`): `TriageAgent` accepts `trust_context`; `run_pipeline` creates a shared backend + `TrustContext` at startup, branches on `fix_confidence == LOW` to escalation vs fix path.
- **Config + gitignore** (`ops-pilot.yml`, `.gitignore`): `trust:` block added to example config; `audit/` added to `.gitignore`.
- **README** updated: Mermaid diagram shows escalation branch and trust layer; architecture file tree current; four new design decision entries; test count 256 → 335.

## Test plan

- [ ] All 335 tests pass (`pytest`)
- [ ] Coverage ≥ 80% (`pytest --cov`)
- [ ] Ruff linting clean (`ruff check agents/ shared/ tests/`)
- [ ] `AuditLog`: daily JSONL rotation, atomic writes, silent failure on write error
- [ ] `ExplanationGenerator`: single backend call, returns `""` on exception, uses correct model
- [ ] `EscalationSummary`: correct fields, fallback on bad JSON/exception
- [ ] `AgentLoop`: audit record written for every tool call; explanation generated only for `REQUIRES_CONFIRMATION`; auto-proceeds with `TrustContext`
- [ ] `NotifyAgent`: escalation path sends human-review message; `ValueError` when both `fix` and `escalation` are `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)