### PR TITLE
chore: add CNAME for ops-pilot.adnankhan.me

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+ops-pilot.adnankhan.me


### PR DESCRIPTION
## Summary
Adds `docs/CNAME` with the value `ops-pilot.adnankhan.me` so GitHub Pages serves this site at the custom subdomain.

## Prerequisite
Matching DNS CNAME record must exist:

```
ops-pilot.adnankhan.me -> adnanafik.github.io
```

Once DNS propagates, old URLs (`adnanafik.github.io/ops-pilot/` and `adnankhan.me/ops-pilot/`) automatically 301-redirect to the new subdomain.

## Test plan
- [ ] DNS record added (external, not part of this PR)
- [ ] GitHub Pages settings show green DNS check after propagation
- [ ] Enforce HTTPS toggle enabled in Pages settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)