### PR TITLE
Improve error message when ANTHROPIC_API_KEY is missing

### DIFF
--- a/scripts/watch_and_fix.py
+++ b/scripts/watch_and_fix.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -64,6 +65,23 @@ def hdr(text: str, color: str = BLUE) -> None:
 def step(agent: str, msg: str, color: str = CYAN) -> None:
     ts = datetime.utcnow().strftime("%H:%M:%S")
     print(f"{DIM}[{ts}]{RESET} {color}{BOLD}{agent:12}{RESET} {msg}")
+
+
+def validate_env() -> None:
+    """Exit with a clear message if required environment variables are missing."""
+    demo_mode = os.getenv("DEMO_MODE", "false").lower() == "true"
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+
+    if not demo_mode and not api_key:
+        return
+    print(
+        f"\n{RED}{BOLD}ops-pilot: missing required environment variable{RESET}\n\n"
+        f"  {BOLD}ANTHROPIC_API_KEY{RESET} is not set.\n\n"
+        f"Please set it in your .env file.\n"
+        f"See Quickstart: https://github.com/adnanafik/ops-pilot#quickstart\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 # ── Pipeline runner ────────────────────────────────────────────────────────────
@@ -267,7 +285,6 @@ def main() -> None:
     parser.add_argument("--once", action="store_true", help="Process current failures and exit")
     parser.add_argument("--dry-run", action="store_true", help="Triage only — no PRs or Slack")
     args = parser.parse_args()
-
     cfg = load_config(args.config)
 
     logging.basicConfig(

--- a/scripts/watch_and_fix.py
+++ b/scripts/watch_and_fix.py
@@ -70,18 +70,20 @@ def step(agent: str, msg: str, color: str = CYAN) -> None:
 def validate_env() -> None:
     """Exit with a clear message if required environment variables are missing."""
     demo_mode = os.getenv("DEMO_MODE", "false").lower() == "true"
-    api_key = os.getenv("ANTHROPIC_API_KEY")
+    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
 
-    if not demo_mode and not api_key:
+    if demo_mode:
         return
-    print(
-        f"\n{RED}{BOLD}ops-pilot: missing required environment variable{RESET}\n\n"
-        f"  {BOLD}ANTHROPIC_API_KEY{RESET} is not set.\n\n"
-        f"Please set it in your .env file.\n"
-        f"See Quickstart: https://github.com/adnanafik/ops-pilot#quickstart\n",
-        file=sys.stderr,
-    )
-    sys.exit(1)
+
+    if not api_key:
+        print(
+            f"\n{RED}{BOLD}ops-pilot: missing required environment variable{RESET}\n\n"
+            f"  {BOLD}ANTHROPIC_API_KEY{RESET} is not set.\n\n"
+            f"Please set it in your .env file.\n"
+            f"See Quickstart: https://github.com/adnanafik/ops-pilot#quickstart\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 # ── Pipeline runner ────────────────────────────────────────────────────────────
@@ -285,6 +287,7 @@ def main() -> None:
     parser.add_argument("--once", action="store_true", help="Process current failures and exit")
     parser.add_argument("--dry-run", action="store_true", help="Triage only — no PRs or Slack")
     args = parser.parse_args()
+    validate_env()
     cfg = load_config(args.config)
 
     logging.basicConfig(

--- a/tests/test_missing_api_key.py
+++ b/tests/test_missing_api_key.py
@@ -1,0 +1,27 @@
+import subprocess
+import os
+import sys
+
+
+def test_missing_anthropic_api_key():
+    env = os.environ.copy()
+
+    # Ensure API key is NOT set
+    env.pop("ANTHROPIC_API_KEY", None)
+
+    # Disable demo mode so validation triggers
+    env["DEMO_MODE"] = "false"
+
+    result = subprocess.run(
+        [sys.executable, "scripts/watch_and_fix.py", "--once"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # Check exit code
+    assert result.returncode != 0
+
+    # Check error message
+    assert "ANTHROPIC_API_KEY" in result.stderr
+    assert "Quickstart" in result.stderr


### PR DESCRIPTION
## Summary
Improves the error message when ANTHROPIC_API_KEY is missing.

## Changes
- Added early validation for ANTHROPIC_API_KEY in watch_and_fix.py
- Displays a clear, user-friendly error message
- Includes reference to .env.example and Quickstart docs
- Exits with non-zero status code when missing

## Test
- Added test to verify behavior when ANTHROPIC_API_KEY is unset
- Ensures:
  - Error message contains "ANTHROPIC_API_KEY"
  - Includes Quickstart reference
  - Returns non-zero exit code

## Notes
- Validation is skipped when DEMO_MODE=true to preserve demo functionality